### PR TITLE
GG-49287 Bulk decode of primitive arrays (vectorized float-vector deserialization)

### DIFF
--- a/pygridgain/datatypes/primitive_arrays.py
+++ b/pygridgain/datatypes/primitive_arrays.py
@@ -185,7 +185,12 @@ class PrimitiveArrayObject(Nullable):
 
     @classmethod
     def to_python_not_null(cls, ctypes_object, **kwargs):
-        return [ctypes_object.data[i] for i in range(ctypes_object.length)]
+        # Bulk buffer decode instead of an element-wise Python list comprehension over the
+        # ctypes array (~the dominant client cost for large float vectors). Cast through bytes
+        # to the native element format (ctypes LittleEndianStructure reports e.g. '<f', which
+        # memoryview.tolist() rejects); correct on little-endian platforms.
+        mv = memoryview(ctypes_object.data)
+        return mv.cast('B').cast(mv.format.lstrip('<>=!@')).tolist()
 
     @classmethod
     def from_python_not_null(cls, stream, value, **kwargs):

--- a/pygridgain/datatypes/primitive_arrays.py
+++ b/pygridgain/datatypes/primitive_arrays.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import ctypes
+import sys
 from io import SEEK_CUR
 
 from pygridgain.constants import *
@@ -31,6 +32,28 @@ __all__ = [
     'FloatArray', 'FloatArrayObject', 'DoubleArray', 'DoubleArrayObject',
     'CharArray', 'CharArrayObject', 'BoolArray', 'BoolArrayObject',
 ]
+
+
+def _bulk_to_python(ctypes_object):
+    """
+    Decode a ctypes primitive array into a Python list in a single C-level pass.
+
+    Replaces the element-wise ``[data[i] for i in range(length)]`` comprehension,
+    which is the dominant client cost for large primitive arrays (e.g. the 1536-d
+    float vector returned per vector-query result row): ``memoryview.tolist()``
+    unpacks the whole buffer in one C loop instead of one ctypes ``__getitem__``
+    (offset + bounds-check + box) per element.
+
+    ``memoryview.cast()`` only accepts a native byte-order format, while the array
+    is a ``LittleEndianStructure`` that reports an explicit prefix (e.g. ``'<f'``).
+    On a little-endian host the reinterpret is a no-op, so we strip the prefix and
+    bulk-decode; on a big-endian host that would misread the bytes, so we keep the
+    correct (and there, equally cheap relative to the byte-swap) element-wise path.
+    """
+    if sys.byteorder == 'little':
+        mv = memoryview(ctypes_object.data)
+        return mv.cast('B').cast(mv.format.lstrip('<>=!@')).tolist()
+    return [ctypes_object.data[i] for i in range(ctypes_object.length)]
 
 
 class PrimitiveArray(GridGainDataType):
@@ -68,7 +91,7 @@ class PrimitiveArray(GridGainDataType):
 
     @classmethod
     def to_python(cls, ctypes_object, **kwargs):
-        return [ctypes_object.data[i] for i in range(ctypes_object.length)]
+        return _bulk_to_python(ctypes_object)
 
     @classmethod
     def _write_header(cls, stream, value):
@@ -185,12 +208,7 @@ class PrimitiveArrayObject(Nullable):
 
     @classmethod
     def to_python_not_null(cls, ctypes_object, **kwargs):
-        # Bulk buffer decode instead of an element-wise Python list comprehension over the
-        # ctypes array (~the dominant client cost for large float vectors). Cast through bytes
-        # to the native element format (ctypes LittleEndianStructure reports e.g. '<f', which
-        # memoryview.tolist() rejects); correct on little-endian platforms.
-        mv = memoryview(ctypes_object.data)
-        return mv.cast('B').cast(mv.format.lstrip('<>=!@')).tolist()
+        return _bulk_to_python(ctypes_object)
 
     @classmethod
     def from_python_not_null(cls, stream, value, **kwargs):

--- a/tests/test_primitive_arrays.py
+++ b/tests/test_primitive_arrays.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2021 GridGain Systems, Inc. and Contributors.
+#
+# Licensed under the GridGain Community Edition License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Server-free coverage for the bulk primitive-array deserialization fast path
+(:func:`pygridgain.datatypes.primitive_arrays._bulk_to_python`, GG-49287).
+
+These exercise the real serialize -> parse -> read_ctype -> to_python codec
+without a running node, so the decode path is checked in CI's unit run rather
+than only via the live put/get round-trips in ``tests/common/test_datatypes.py``.
+"""
+import sys
+
+import pytest
+
+from pygridgain.datatypes.primitive_arrays import (
+    _bulk_to_python,
+    ByteArrayObject, ShortArrayObject, IntArrayObject, LongArrayObject,
+    FloatArrayObject, DoubleArrayObject, CharArrayObject, BoolArrayObject,
+    FloatArray, IntArray, ShortArray, LongArray, DoubleArray,
+)
+from pygridgain.stream.binary_stream import BinaryStream
+
+
+def _serialize(datatype, value):
+    stream = BinaryStream(None)
+    datatype.from_python(stream, value)
+    return stream.getvalue()
+
+
+def _to_ctypes_object(datatype, value):
+    stream = BinaryStream(None, _serialize(datatype, value))
+    c_type = datatype.parse(stream)
+    return stream.read_ctype(c_type, position=0)
+
+
+def _roundtrip(datatype, value):
+    return datatype.to_python(_to_ctypes_object(datatype, value))
+
+
+# Values chosen to be exactly representable (incl. float32 for FloatArray*) so
+# equality holds after a real serialize/deserialize round-trip.
+NUMERIC_CASES = [
+    (ShortArrayObject, [-32768, -1, 0, 1, 32767, 12345]),
+    (IntArrayObject, [-2 ** 31, -1, 0, 1, 2 ** 31 - 1, 987654321]),
+    (LongArrayObject, [-2 ** 63, -1, 0, 1, 2 ** 63 - 1, 10 ** 18]),
+    (FloatArrayObject, [0.0, 1.0, -1.0, 1.5, -2.25, 0.5, 1024.0, -4096.0]),
+    (DoubleArrayObject, [0.0, 1.0, -1.0, 1.5, -2.25, 3.141592653589793, 1e308, -1e-308]),
+    # Payload-only variants (no type code) — exercise PrimitiveArray.to_python.
+    (ShortArray, [-1, 0, 7, 32767]),
+    (IntArray, [-1, 0, 7, 2 ** 31 - 1]),
+    (LongArray, [-1, 0, 7, 2 ** 63 - 1]),
+    (FloatArray, [0.0, 1.5, -2.25, 1024.0]),
+    (DoubleArray, [0.0, 1.5, -2.25, 1e300]),
+]
+
+
+@pytest.mark.parametrize('datatype,value', NUMERIC_CASES)
+def test_numeric_array_roundtrip(datatype, value):
+    assert _roundtrip(datatype, value) == value
+
+
+@pytest.mark.parametrize('datatype', [
+    ShortArrayObject, IntArrayObject, LongArrayObject, FloatArrayObject,
+    DoubleArrayObject, CharArrayObject, BoolArrayObject,
+    ShortArray, IntArray, LongArray, FloatArray, DoubleArray,
+])
+def test_empty_array_roundtrip(datatype):
+    assert _roundtrip(datatype, []) == []
+
+
+def test_byte_array_roundtrip():
+    # ByteArrayObject decodes to ``bytes`` (its own override, not the bulk helper).
+    assert _roundtrip(ByteArrayObject, [0, 1, 127, 255]) == bytes([0, 1, 127, 255])
+    assert _roundtrip(ByteArrayObject, []) == b''
+
+
+def test_bool_array_roundtrip():
+    value = [True, False, True, True, False]
+    assert _roundtrip(BoolArrayObject, value) == value
+
+
+def test_char_array_roundtrip():
+    # BMP characters (same alphabet as the live suite's CharArrayObject case).
+    value = ['A', 'я', 'カ', '好', '€']
+    assert _roundtrip(CharArrayObject, value) == value
+
+
+def test_large_float_vector_is_identical():
+    # The motivating case: a 1536-d float vector returned per query-result row.
+    # Integers < 2**24 are exact in float32, so the decoded list must match.
+    value = [float(i) for i in range(1536)]
+    assert _roundtrip(FloatArrayObject, value) == value
+
+
+def test_bulk_decode_matches_elementwise_and_big_endian_fallback(monkeypatch):
+    """The fast path and the big-endian element-wise fallback agree element-for-element."""
+    value = [0.0, 1.0, -1.0, 1.5, -2.25, 0.5, 1024.0, -4096.0]
+    ctypes_object = _to_ctypes_object(FloatArrayObject, value)
+    reference = [ctypes_object.data[i] for i in range(ctypes_object.length)]
+
+    assert sys.byteorder == 'little'
+    fast = _bulk_to_python(ctypes_object)          # little-endian: memoryview bulk decode
+    assert fast == reference == value
+
+    monkeypatch.setattr(sys, 'byteorder', 'big')   # force the element-wise fallback branch
+    fallback = _bulk_to_python(ctypes_object)
+    assert fallback == reference == value


### PR DESCRIPTION
**Jira:** [GG-49287](https://ggsystems.atlassian.net/browse/GG-49287) — pygridgain: vector protocol v2 + deserialization fast path

## Problem
`PrimitiveArray` deserializes arrays element-by-element:
```python
[ctypes_object.data[i] for i in range(ctypes_object.length)]
```
For the 1536-d float vector returned per vector-query result row this dominates client CPU — cProfile of a kNN loop (500 queries × 100 results) put **~41%** of total client time in this one comprehension (~77M per-element ctypes reads).

## Change
Decode the whole buffer in a single C-level pass via `memoryview.tolist()`:
```python
mv = memoryview(ctypes_object.data)
return mv.cast('B').cast(mv.format.lstrip('<>=!@')).tolist()
```
- **Why it's faster:** the comprehension pays Python loop overhead plus a ctypes `__getitem__` (offset + bounds-check + box) per element; `memoryview.tolist()` walks the buffer in one C loop, leaving element-boxing as the only remaining cost. ~10× on the isolated 1536-float decode.
- **Big-endian safe:** `memoryview.cast()` only accepts a native byte-order format while the buffer is little-endian (`'<f'`). The fast path runs only when `sys.byteorder == 'little'`; on big-endian it falls back to the (correct) element-wise decode.
- Factored into a shared `_bulk_to_python` helper used by both `PrimitiveArrayObject.to_python_not_null` and the payload-only `PrimitiveArray.to_python`, so array-valued object fields get the same win.

## Result
dbpedia-openai 1536-d vector queries, single client, **identical results** (key-checksums unchanged at every efSearch):

| k (results/query) | baseline | this PR | speedup |
|---:|---:|---:|---:|
| 10  | 531 q/s | 736 q/s | 1.39× |
| 100 | 71 q/s  | 126 q/s | 1.77× |
| 800 | 9.7 q/s | 18.2 q/s| 1.88× |

The win grows with the number of result rows deserialized.

## Tests
`tests/test_primitive_arrays.py` — server-free serialize → parse → `to_python` round-trips for every primitive array type, empty arrays, the 1536-d float vector, and big-endian fallback equivalence. Runs in the CI unit suite (no node required); the live put/get coverage in `tests/common/test_datatypes.py` is unchanged.


[GG-49287]: https://ggsystems.atlassian.net/browse/GG-49287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ