### PR TITLE
GG-49286 Adopt vector protocol v2: efSearch, scores, NOCONTENT (feature bit 35)

### DIFF
--- a/pygridgain/aio_cache.py
+++ b/pygridgain/aio_cache.py
@@ -506,10 +506,12 @@ class AioCache(BaseCache):
         :param threshold: similarity threshold, non-positive values disable it.
         :param page_size: (optional) page size. Default size is 1 (slowest
          and safest),
-        :param ef_search: (optional) search beam width: how many graph candidates the engine
-         examines while searching. Larger values improve recall at the cost of latency; values
-         below k are treated as k; 0 or negative (the default) means the engine default.
-         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :param ef_search: (optional) search beam width: how many candidate vectors the engine
+         keeps while traversing the index graph. The engine returns the k best of those
+         candidates, so k controls the result size while the beam controls the search quality:
+         a beam wider than k improves recall at the cost of latency, and a beam below k could
+         not even hold k results, so such values are treated as k. 0 or negative (the default)
+         means the engine default. Requires the QUERY_VECTOR_EXTENDED cluster feature.
         :param with_scores: (optional) append the engine similarity score to every result row.
          Scores are raw engine (Lucene) values: similarity-function-dependent and not normalized.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.

--- a/pygridgain/aio_cache.py
+++ b/pygridgain/aio_cache.py
@@ -33,6 +33,7 @@ from .api.key_value import (
     cache_remove_if_equals_async, cache_replace_if_equals_async, cache_get_size_async,
 )
 from .cursors import AioScanCursor, AioVectorCursor
+from .api.sql import VECTOR_FLAG_NOCONTENT, VECTOR_FLAG_WITH_SCORES
 from .cache import __parse_settings, BaseCache
 
 
@@ -493,7 +494,8 @@ class AioCache(BaseCache):
         return AioScanCursor(self.client, self.cache_info, page_size, partitions, local)
 
     def vector(self, type_name: str, field: str, clause_vector: List[float],
-               k: int, threshold: float, page_size: int = 1) -> AioVectorCursor:
+               k: int, threshold: float, page_size: int = 1, ef_search: int = 0,
+               with_scores: bool = False, no_content: bool = False) -> AioVectorCursor:
         """
         Ignite supports vector queries based on Apache Lucene engine.
 
@@ -501,8 +503,23 @@ class AioCache(BaseCache):
         :param field: Name of the field.
         :param clause_vector: Search vector.
         :param k: [K]NN, how many vectors to return.
+        :param threshold: similarity threshold, non-positive values disable it.
         :param page_size: (optional) page size. Default size is 1 (slowest
          and safest),
-        :return: Scan query cursor.
+        :param ef_search: (optional) search beam width: how many graph candidates the engine
+         examines while searching. Larger values improve recall at the cost of latency; values
+         below k are treated as k; 0 or negative (the default) means the engine default.
+         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :param with_scores: (optional) append the engine similarity score to every result row.
+         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :param no_content: (optional) omit values from result rows - the cheapest response shape.
+         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :return: Async vector query cursor. Rows are shaped by the flags: `(key, value)` by default,
+         `(key, value, score)` with `with_scores`, bare `key` with `no_content`, and
+         `(key, score)` with both.
         """
-        return AioVectorCursor(self.client, self.cache_info, page_size, type_name, field, clause_vector, k, threshold)
+        query_flags = ((VECTOR_FLAG_WITH_SCORES if with_scores else 0)
+                       | (VECTOR_FLAG_NOCONTENT if no_content else 0))
+
+        return AioVectorCursor(self.client, self.cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                               ef_search, query_flags)

--- a/pygridgain/aio_cache.py
+++ b/pygridgain/aio_cache.py
@@ -511,6 +511,7 @@ class AioCache(BaseCache):
          below k are treated as k; 0 or negative (the default) means the engine default.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.
         :param with_scores: (optional) append the engine similarity score to every result row.
+         Scores are raw engine (Lucene) values: similarity-function-dependent and not normalized.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.
         :param no_content: (optional) omit values from result rows - the cheapest response shape.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.

--- a/pygridgain/api/sql.py
+++ b/pygridgain/api/sql.py
@@ -16,10 +16,11 @@
 from typing import Union, List
 
 from pygridgain.connection import AioConnection, Connection
-from pygridgain.datatypes import AnyDataArray, AnyDataObject, Bool, Int, Long, Map, Null, String, StructArray, \
+from pygridgain.datatypes import AnyDataArray, AnyDataObject, Bool, Byte, Int, Long, Map, Null, String, StructArray, \
     FloatArrayObject
 from pygridgain.datatypes import Float as PyFloat
 from pygridgain.datatypes.sql import StatementType
+from pygridgain.exceptions import NotSupportedByClusterError
 from pygridgain.queries import Query, query_perform
 from pygridgain.queries.op_codes import (
     OP_QUERY_SCAN, OP_QUERY_SCAN_CURSOR_GET_PAGE, OP_QUERY_SQL, OP_QUERY_SQL_CURSOR_GET_PAGE, OP_QUERY_SQL_FIELDS,
@@ -29,6 +30,12 @@ from pygridgain.utils import deprecated
 from .result import APIResult
 from ..queries.cache_info import CacheInfo
 from ..queries.response import SQLResponse
+
+#: Vector query flag: append the engine similarity score to every result row.
+VECTOR_FLAG_WITH_SCORES = 1
+
+#: Vector query flag: omit value objects from result rows (keys, and optionally scores, only).
+VECTOR_FLAG_NOCONTENT = 2
 
 
 def scan(conn: 'Connection', cache_info: CacheInfo, page_size: int, partitions: int = -1,
@@ -447,7 +454,8 @@ def __post_process_sql_fields_cursor(result):
 
 
 def vector(conn: 'Connection', cache_info: CacheInfo, page_size: int,
-           type_name: str, field: str, clause_vector: List[float], k: int, threshold: float) -> APIResult:
+           type_name: str, field: str, clause_vector: List[float], k: int, threshold: float,
+           ef_search: int = 0, query_flags: int = 0) -> APIResult:
     """
     Performs vector query.
     Vector queries based on Apache Lucene engine.
@@ -459,6 +467,11 @@ def vector(conn: 'Connection', cache_info: CacheInfo, page_size: int,
     :param field: Name of the field.
     :param clause_vector: Search vector.
     :param k: [K]NN, how many vectors to return.
+    :param threshold: similarity threshold, non-positive values disable it.
+    :param ef_search: (optional) search beam width, 0 or negative means the engine default.
+     Requires the QUERY_VECTOR_EXTENDED cluster feature.
+    :param query_flags: (optional) combination of VECTOR_FLAG_WITH_SCORES and VECTOR_FLAG_NOCONTENT.
+     Requires the QUERY_VECTOR_EXTENDED cluster feature.
     :return: API result data object. Contains zero status and a value
      of type dict with results on success, non-zero status and an error
      description otherwise.
@@ -466,80 +479,119 @@ def vector(conn: 'Connection', cache_info: CacheInfo, page_size: int,
      Value dict is of following format:
 
      * `cursor`: int, cursor ID,
-     * `data`: dict, result rows as key-value pairs,
+     * `data`: result rows - a dict of key-value pairs when `query_flags` is 0, otherwise
+       a list of per-row dicts with `key`, optionally `value` (no VECTOR_FLAG_NOCONTENT) and
+       optionally `score` (VECTOR_FLAG_WITH_SCORES) entries,
      * `more`: bool, True if more data is available for subsequent
        ‘vector_cursor_get_page’ calls.
     """
-    return __vector(conn, cache_info, page_size, type_name, field, clause_vector, k, threshold)
+    return __vector(conn, cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                    ef_search, query_flags)
 
 
 async def vector_async(conn: 'AioConnection', cache_info: CacheInfo, page_size: int,
-                       type_name: str, field: str, clause_vector: List[float], k: int, threshold: float) -> APIResult:
+                       type_name: str, field: str, clause_vector: List[float], k: int, threshold: float,
+                       ef_search: int = 0, query_flags: int = 0) -> APIResult:
     """
     Async version of vector.
     """
-    return await __vector(conn, cache_info, page_size, type_name, field, clause_vector, k, threshold)
+    return await __vector(conn, cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                          ef_search, query_flags)
 
 
-def __vector(conn, cache_info, page_size, type_name, field, clause_vector, k, threshold):
-    query_struct = Query(
-        OP_QUERY_VECTOR,
-        [
-            ('cache_info', CacheInfo),
-            ('page_size', Int),
-            ('type_name', String),
-            ('field', String),
-            ('clause_vector', FloatArrayObject),
-            ('k', Int),
-            ('threshold', PyFloat),
+def __vector_rows_type(query_flags):
+    """
+    Response rows encoding: a plain key-value sequence for legacy queries, a row struct shaped
+    by the flags otherwise.
+    """
+    if not query_flags:
+        return Map
+
+    row = [('key', AnyDataObject)]
+
+    if not query_flags & VECTOR_FLAG_NOCONTENT:
+        row.append(('value', AnyDataObject))
+
+    if query_flags & VECTOR_FLAG_WITH_SCORES:
+        row.append(('score', PyFloat))
+
+    return StructArray(row)
+
+
+def __vector(conn, cache_info, page_size, type_name, field, clause_vector, k, threshold, ef_search, query_flags):
+    fields = [
+        ('cache_info', CacheInfo),
+        ('page_size', Int),
+        ('type_name', String),
+        ('field', String),
+        ('clause_vector', FloatArrayObject),
+        ('k', Int),
+        ('threshold', PyFloat),
+    ]
+
+    query_params = {
+        'cache_info': cache_info,
+        'page_size': page_size,
+        'type_name': type_name,
+        'field': field,
+        'clause_vector': clause_vector,
+        'k': k,
+        'threshold': threshold,
+    }
+
+    if conn.protocol_context.is_query_vector_extended_supported():
+        # The extended fields are mandatory on the wire once the feature is negotiated.
+        fields += [
+            ('ef_search', Int),
+            ('query_flags', Byte),
         ]
-    )
+
+        query_params['ef_search'] = ef_search
+        query_params['query_flags'] = query_flags
+    elif ef_search > 0 or query_flags:
+        raise NotSupportedByClusterError('The cluster does not support extended vector queries '
+                                         '(efSearch, scores, NOCONTENT) - QUERY_VECTOR_EXTENDED feature is absent.')
+
+    query_struct = Query(OP_QUERY_VECTOR, fields)
 
     return query_perform(
         query_struct, conn,
-        query_params={
-            'cache_info': cache_info,
-            'page_size': page_size,
-            'type_name': type_name,
-            'field': field,
-            'clause_vector': clause_vector,
-            'k': k,
-            'threshold': threshold,
-        },
+        query_params=query_params,
         response_config=[
             ('cursor', Long),
-            ('data', Map),
+            ('data', __vector_rows_type(query_flags)),
             ('more', Bool),
         ],
         post_process_fun=__query_result_post_process
     )
 
 
-def vector_cursor_get_page(conn: 'Connection', cursor: int) -> APIResult:
+def vector_cursor_get_page(conn: 'Connection', cursor: int, query_flags: int = 0) -> APIResult:
     """
     Fetches the next vector query cursor page by cursor ID that is obtained
     from `vector` function.
 
     :param conn: connection to GridGain server,
     :param cursor: cursor ID,
+    :param query_flags: (optional) the flags of the originating query - pages keep its row shape.
     :return: API result data object. Contains zero status and a value
      of type dict with results on success, non-zero status and an error
      description otherwise.
 
      Value dict is of following format:
 
-     * `data`: dict, result rows as key-value pairs,
+     * `data`: result rows, shaped as in the `vector` function response,
      * `more`: bool, True if more data is available for subsequent
        ‘vector_cursor_get_page’ calls.
     """
-    return __vector_cursor_get_page(conn, cursor)
+    return __vector_cursor_get_page(conn, cursor, query_flags)
 
 
-async def vector_cursor_get_page_async(conn: 'AioConnection', cursor: int) -> APIResult:
-    return await __vector_cursor_get_page(conn, cursor)
+async def vector_cursor_get_page_async(conn: 'AioConnection', cursor: int, query_flags: int = 0) -> APIResult:
+    return await __vector_cursor_get_page(conn, cursor, query_flags)
 
 
-def __vector_cursor_get_page(conn, cursor):
+def __vector_cursor_get_page(conn, cursor, query_flags):
     query_struct = Query(
         OP_QUERY_VECTOR_CURSOR_GET_PAGE,
         [
@@ -552,7 +604,7 @@ def __vector_cursor_get_page(conn, cursor):
             'cursor': cursor,
         },
         response_config=[
-            ('data', Map),
+            ('data', __vector_rows_type(query_flags)),
             ('more', Bool),
         ],
         post_process_fun=__query_result_post_process

--- a/pygridgain/api/sql.py
+++ b/pygridgain/api/sql.py
@@ -32,6 +32,7 @@ from ..queries.cache_info import CacheInfo
 from ..queries.response import SQLResponse
 
 #: Vector query flag: append the engine similarity score to every result row.
+#: Scores are raw engine (Lucene) values: similarity-function-dependent and not normalized.
 VECTOR_FLAG_WITH_SCORES = 1
 
 #: Vector query flag: omit value objects from result rows (keys, and optionally scores, only).

--- a/pygridgain/cache.py
+++ b/pygridgain/cache.py
@@ -33,6 +33,7 @@ from .api.key_value import (
     cache_remove_if_equals, cache_replace_if_equals, cache_get_size
 )
 from .cursors import ScanCursor, SqlCursor, VectorCursor
+from .api.sql import VECTOR_FLAG_NOCONTENT, VECTOR_FLAG_WITH_SCORES
 
 PROP_CODES = set([
     getattr(prop_codes, x)
@@ -659,7 +660,8 @@ class Cache(BaseCache):
                          distributed_joins, replicated_only, local, timeout)
 
     def vector(self, type_name: str, field: str, clause_vector: List[float],
-               k: int, threshold: float, page_size: int = 1) -> VectorCursor:
+               k: int, threshold: float, page_size: int = 1, ef_search: int = 0,
+               with_scores: bool = False, no_content: bool = False) -> VectorCursor:
         """
         Ignite supports vector queries based on Apache Lucene engine.
 
@@ -667,8 +669,23 @@ class Cache(BaseCache):
         :param field: Name of the field.
         :param clause_vector: Search vector.
         :param k: [K]NN, how many vectors to return.
+        :param threshold: similarity threshold, non-positive values disable it.
         :param page_size: (optional) page size. Default size is 1 (slowest
          and safest),
-        :return: Scan query cursor.
+        :param ef_search: (optional) search beam width: how many graph candidates the engine
+         examines while searching. Larger values improve recall at the cost of latency; values
+         below k are treated as k; 0 or negative (the default) means the engine default.
+         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :param with_scores: (optional) append the engine similarity score to every result row.
+         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :param no_content: (optional) omit values from result rows - the cheapest response shape.
+         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :return: Vector query cursor. Rows are shaped by the flags: `(key, value)` by default,
+         `(key, value, score)` with `with_scores`, bare `key` with `no_content`, and
+         `(key, score)` with both.
         """
-        return VectorCursor(self.client, self.cache_info, page_size, type_name, field, clause_vector, k, threshold)
+        query_flags = ((VECTOR_FLAG_WITH_SCORES if with_scores else 0)
+                       | (VECTOR_FLAG_NOCONTENT if no_content else 0))
+
+        return VectorCursor(self.client, self.cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                            ef_search, query_flags)

--- a/pygridgain/cache.py
+++ b/pygridgain/cache.py
@@ -677,6 +677,7 @@ class Cache(BaseCache):
          below k are treated as k; 0 or negative (the default) means the engine default.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.
         :param with_scores: (optional) append the engine similarity score to every result row.
+         Scores are raw engine (Lucene) values: similarity-function-dependent and not normalized.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.
         :param no_content: (optional) omit values from result rows - the cheapest response shape.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.

--- a/pygridgain/cache.py
+++ b/pygridgain/cache.py
@@ -672,10 +672,12 @@ class Cache(BaseCache):
         :param threshold: similarity threshold, non-positive values disable it.
         :param page_size: (optional) page size. Default size is 1 (slowest
          and safest),
-        :param ef_search: (optional) search beam width: how many graph candidates the engine
-         examines while searching. Larger values improve recall at the cost of latency; values
-         below k are treated as k; 0 or negative (the default) means the engine default.
-         Requires the QUERY_VECTOR_EXTENDED cluster feature.
+        :param ef_search: (optional) search beam width: how many candidate vectors the engine
+         keeps while traversing the index graph. The engine returns the k best of those
+         candidates, so k controls the result size while the beam controls the search quality:
+         a beam wider than k improves recall at the cost of latency, and a beam below k could
+         not even hold k results, so such values are treated as k. 0 or negative (the default)
+         means the engine default. Requires the QUERY_VECTOR_EXTENDED cluster feature.
         :param with_scores: (optional) append the engine similarity score to every result row.
          Scores are raw engine (Lucene) values: similarity-function-dependent and not normalized.
          Requires the QUERY_VECTOR_EXTENDED cluster feature.

--- a/pygridgain/connection/bitmask_feature.py
+++ b/pygridgain/connection/bitmask_feature.py
@@ -23,6 +23,7 @@ from pygridgain.constants import PROTOCOL_BYTE_ORDER
 class BitmaskFeature(IntFlag):
     CLUSTER_API = 1 << 2
     QUERY_INDEX_VECTOR_SIMILARITY = 1 << 33
+    QUERY_VECTOR_EXTENDED = 1 << 35
 
     def __bytes__(self) -> bytes:
         """

--- a/pygridgain/connection/protocol_context.py
+++ b/pygridgain/connection/protocol_context.py
@@ -127,5 +127,12 @@ class ProtocolContext:
         """
         return self.features and BitmaskFeature.QUERY_INDEX_VECTOR_SIMILARITY in self.features
 
+    def is_query_vector_extended_supported(self) -> bool:
+        """
+        Check whether the extended vector query (efSearch, scores, NOCONTENT) is supported
+        by the cluster.
+        """
+        return self.features and BitmaskFeature.QUERY_VECTOR_EXTENDED in self.features
+
     def is_expiry_policy_supported(self) -> bool:
         return self.version >= (1, 6, 0)

--- a/pygridgain/cursors.py
+++ b/pygridgain/cursors.py
@@ -24,7 +24,10 @@ from pygridgain.api import (
     scan, scan_cursor_get_page, resource_close, scan_async, scan_cursor_get_page_async, resource_close_async, sql,
     sql_cursor_get_page, sql_fields, sql_fields_cursor_get_page, sql_fields_cursor_get_page_async, sql_fields_async
 )
-from pygridgain.api.sql import vector, vector_cursor_get_page, vector_async, vector_cursor_get_page_async
+from pygridgain.api.sql import (
+    VECTOR_FLAG_NOCONTENT, VECTOR_FLAG_WITH_SCORES, vector, vector_cursor_get_page, vector_async,
+    vector_cursor_get_page_async
+)
 from pygridgain.exceptions import CacheError, SQLError
 
 
@@ -387,7 +390,8 @@ class AioSqlFieldsCursor(AbstractSqlFieldsCursor, AioCursorMixin):
 
 
 class AbstractVectorCursor:
-    def __init__(self, client, cache_info, page_size, type_name, field, clause_vector, k, threshold):
+    def __init__(self, client, cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                 ef_search=0, query_flags=0):
         self.client = client
         self.cache_info = cache_info
         self._page_size = page_size
@@ -396,26 +400,33 @@ class AbstractVectorCursor:
         self._clause_vector = clause_vector
         self._k = k
         self._threshold = threshold
+        self._ef_search = ef_search
+        self._query_flags = query_flags
 
     def _finalize_init(self, result):
         if result.status != 0:
             raise CacheError(result.message)
 
         self.cursor_id, self.more = result.value['cursor'], result.value['more']
-        self.data = iter(result.value['data'].items())
+        self.data = self._rows_iter(result.value['data'])
 
     def _process_page_response(self, result):
         if result.status != 0:
             raise CacheError(result.message)
 
-        self.data, self.more = iter(result.value['data'].items()), result.value['more']
+        self.data, self.more = self._rows_iter(result.value['data']), result.value['more']
+
+    def _rows_iter(self, data):
+        # Legacy responses are key-value maps; flagged responses are lists of per-row dicts.
+        return iter(data if self._query_flags else data.items())
 
 
 class VectorCursor(AbstractVectorCursor, CursorMixin):
     """
     Synchronous vector cursor.
     """
-    def __init__(self, client, cache_info, page_size, type_name, field, clause_vector, k, threshold):
+    def __init__(self, client, cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                 ef_search=0, query_flags=0):
         """
         :param client: Synchronous client.
         :param cache_info: Cache meta info.
@@ -424,12 +435,16 @@ class VectorCursor(AbstractVectorCursor, CursorMixin):
         :param field: Name of the field.
         :param clause_vector: Search vector.
         :param k: [K]NN, how many vectors to return.
+        :param ef_search: search beam width, 0 or negative means the engine default.
+        :param query_flags: combination of VECTOR_FLAG_WITH_SCORES and VECTOR_FLAG_NOCONTENT.
         """
-        super().__init__(client, cache_info, page_size, type_name, field, clause_vector, k, threshold)
+        super().__init__(client, cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                         ef_search, query_flags)
 
         self.connection = self.client.random_node
         result = vector(self.connection, self.cache_info, self._page_size,
-                        self._type_name, self._field, self._clause_vector, self._k, self._threshold)
+                        self._type_name, self._field, self._clause_vector, self._k, self._threshold,
+                        self._ef_search, self._query_flags)
         self._finalize_init(result)
 
     def __next__(self):
@@ -437,22 +452,38 @@ class VectorCursor(AbstractVectorCursor, CursorMixin):
             raise StopIteration
 
         try:
-            k, v = next(self.data)
+            row = next(self.data)
         except StopIteration:
             if self.more:
-                self._process_page_response(vector_cursor_get_page(self.connection, self.cursor_id))
-                k, v = next(self.data)
+                self._process_page_response(
+                    vector_cursor_get_page(self.connection, self.cursor_id, self._query_flags))
+                row = next(self.data)
             else:
                 raise StopIteration
 
-        return self.client.unwrap_binary(k), self.client.unwrap_binary(v)
+        if not self._query_flags:
+            k, v = row
+            return self.client.unwrap_binary(k), self.client.unwrap_binary(v)
+
+        key = self.client.unwrap_binary(row['key'])
+
+        if self._query_flags & VECTOR_FLAG_NOCONTENT:
+            if self._query_flags & VECTOR_FLAG_WITH_SCORES:
+                return key, row['score']
+
+            return key
+
+        value = self.client.unwrap_binary(row['value'])
+
+        return key, value, row['score']
 
 
 class AioVectorCursor(AbstractVectorCursor, AioCursorMixin):
     """
     Asynchronous vector query cursor.
     """
-    def __init__(self, client, cache_info, page_size, type_name, field, clause_vector, k, threshold):
+    def __init__(self, client, cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                 ef_search=0, query_flags=0):
         """
         :param client: Asynchronous client.
         :param cache_info: Cache meta info.
@@ -461,14 +492,18 @@ class AioVectorCursor(AbstractVectorCursor, AioCursorMixin):
         :param field: Name of the field.
         :param clause_vector: Search vector.
         :param k: [K]NN, how many vectors to return.
+        :param ef_search: search beam width, 0 or negative means the engine default.
+        :param query_flags: combination of VECTOR_FLAG_WITH_SCORES and VECTOR_FLAG_NOCONTENT.
         """
-        super().__init__(client, cache_info, page_size, type_name, field, clause_vector, k, threshold)
+        super().__init__(client, cache_info, page_size, type_name, field, clause_vector, k, threshold,
+                         ef_search, query_flags)
 
     async def __aenter__(self):
         if not self.connection:
             self.connection = await self.client.random_node()
             result = await vector_async(self.connection, self.cache_info, self._page_size,
-                                        self._type_name, self._field, self._clause_vector, self._k, self._threshold)
+                                        self._type_name, self._field, self._clause_vector, self._k, self._threshold,
+                                        self._ef_search, self._query_flags)
             self._finalize_init(result)
         return self
 
@@ -480,17 +515,32 @@ class AioVectorCursor(AbstractVectorCursor, AioCursorMixin):
             raise StopAsyncIteration
 
         try:
-            k, v = next(self.data)
+            row = next(self.data)
         except StopIteration:
             if self.more:
-                self._process_page_response(await vector_cursor_get_page_async(self.connection, self.cursor_id))
+                self._process_page_response(
+                    await vector_cursor_get_page_async(self.connection, self.cursor_id, self._query_flags))
                 try:
-                    k, v = next(self.data)
+                    row = next(self.data)
                 except StopIteration:
                     raise StopAsyncIteration
             else:
                 raise StopAsyncIteration
 
-        return await asyncio.gather(
-            *[self.client.unwrap_binary(k), self.client.unwrap_binary(v)]
-        )
+        if not self._query_flags:
+            k, v = row
+            return await asyncio.gather(
+                *[self.client.unwrap_binary(k), self.client.unwrap_binary(v)]
+            )
+
+        key = await self.client.unwrap_binary(row['key'])
+
+        if self._query_flags & VECTOR_FLAG_NOCONTENT:
+            if self._query_flags & VECTOR_FLAG_WITH_SCORES:
+                return key, row['score']
+
+            return key
+
+        value = await self.client.unwrap_binary(row['value'])
+
+        return key, value, row['score']


### PR DESCRIPTION
Jira: [GG-49286](https://ggsystems.atlassian.net/browse/GG-49286)

Client side of the extended vector query protocol. Server counterparts: CE https://github.com/gridgain/gridgain/pull/3801 (protocol + SPI) and EE https://github.com/ggprivate/ggprivate/pull/2276 (engine) — this PR is useful once those merge; against older clusters everything degrades cleanly (see below).

## What changes

- `BitmaskFeature.QUERY_VECTOR_EXTENDED (1 << 35)` advertised in the handshake; the extended request fields (`ef_search` i32 + `query_flags` i8) are appended whenever the cluster negotiated the feature, per the wire contract (mandatory-once-negotiated).
- `Cache.vector()` / `AioCache.vector()` gain `ef_search`, `with_scores` and `no_content` parameters. Result rows are shaped by the flags:
  - default: `(key, value)` — unchanged
  - `with_scores`: `(key, value, score)` — score is the raw engine (Lucene) value, similarity-function-dependent, not normalized
  - `no_content`: bare `key`
  - both: `(key, score)` — the cheapest useful ANN response (response deserialization is ~92% of the client-side query cost)
- Flagged responses parse as row structs (`StructArray`) instead of the legacy key-value map; cursor pages (op 30001) keep the shape of the originating query. Legacy responses take the untouched `Map` path.
- Requesting v2 options against a cluster without the feature raises `NotSupportedByClusterError` instead of silently degrading.

## Verification

- Two-cycle self-review (Codex xhigh + independent subagent): no P1/P2 findings survived; doc fixes applied.
- **e2e against a live GG8 node built from the gg-49286 server branches** (real EE Lucene engine, known cosine geometry): **16/16 checks** — legacy-shape regression, negotiation, efSearch pass-through, exact wire scores, NOCONTENT, key+score, paging via op 30001 with flags, threshold composition, sync + asyncio parity.
- **Released pygridgain 1.5.0 against the same new server: 6/6 checks** — the true legacy-client compatibility proof (v1 shape byte-identical, bit 35 unknown to the client).

Note for [GG-49932](https://ggsystems.atlassian.net/browse/GG-49932): protocol v2 adoption moved here per scope decision; 49932 keeps the remaining client fast paths (unwrap_binary, paging default, benchmark rerun).

[GG-49286]: https://ggsystems.atlassian.net/browse/GG-49286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GG-49932]: https://ggsystems.atlassian.net/browse/GG-49932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ