### PR TITLE
GG-50683 Bulk-encode primitive arrays and memoize c_type construction

### DIFF
--- a/pygridgain/aio_cache.py
+++ b/pygridgain/aio_cache.py
@@ -501,7 +501,11 @@ class AioCache(BaseCache):
 
         :param type_name: Name of the type.
         :param field: Name of the field.
-        :param clause_vector: Search vector.
+        :param clause_vector: Search vector. Any sequence of floats works; an array already in wire
+         layout (e.g. a numpy array of dtype ``'<f4'``) is written straight through without
+         per-element conversion and is by far the cheapest to send, which matters because embedding
+         dimensions are typically in the hundreds or thousands. Converting such an array to a Python
+         list before passing it costs more than the query itself.
         :param k: [K]NN, how many vectors to return.
         :param threshold: similarity threshold, non-positive values disable it.
         :param page_size: (optional) page size. Default size is 1 (slowest

--- a/pygridgain/cache.py
+++ b/pygridgain/cache.py
@@ -667,7 +667,11 @@ class Cache(BaseCache):
 
         :param type_name: Name of the type.
         :param field: Name of the field.
-        :param clause_vector: Search vector.
+        :param clause_vector: Search vector. Any sequence of floats works; an array already in wire
+         layout (e.g. a numpy array of dtype ``'<f4'``) is written straight through without
+         per-element conversion and is by far the cheapest to send, which matters because embedding
+         dimensions are typically in the hundreds or thousands. Converting such an array to a Python
+         list before passing it costs more than the query itself.
         :param k: [K]NN, how many vectors to return.
         :param threshold: similarity threshold, non-positive values disable it.
         :param page_size: (optional) page size. Default size is 1 (slowest

--- a/pygridgain/datatypes/internal.py
+++ b/pygridgain/datatypes/internal.py
@@ -16,6 +16,7 @@
 import asyncio
 from collections import OrderedDict
 import ctypes
+import functools
 import decimal
 from datetime import date, datetime, timedelta
 from io import SEEK_CUR
@@ -233,6 +234,24 @@ class StructArray:
         )
 
 
+def _make_struct_c_type(fields):
+    return type(
+        'StructLE',
+        (ctypes.LittleEndianStructure,),
+        {
+            '_pack_': 1,
+            '_fields_': list(fields),
+        },
+    )
+
+
+@functools.lru_cache(maxsize=2048)
+def _cached_struct_c_type(fields):
+    """One ctypes Structure per distinct field shape. Bounded so an unusual workload cannot grow it
+    without limit; identical shapes recur constantly, so the hit rate is effectively 100%."""
+    return _make_struct_c_type(fields)
+
+
 @attr.s
 class Struct:
     """ Sequence of fields, including variable-sized and nested. """
@@ -274,14 +293,16 @@ class Struct:
 
     @staticmethod
     def build_c_type(fields):
-        return type(
-            'StructLE',
-            (ctypes.LittleEndianStructure,),
-            {
-                '_pack_': 1,
-                '_fields_': fields,
-            },
-        )
+        # Memoized: building a ctypes Structure calls type(), which allocates a class and computes a
+        # struct layout. A response with N rows built N of them, all identical — for a k-NN query
+        # returning 10 ids that was 10 class creations per query, and it was the top identifiable
+        # client frame after bulk encoding landed. The result is only ever read (sizeof,
+        # from_buffer_copy, read_ctype), never mutated, so one shared class per shape is safe.
+        try:
+            return _cached_struct_c_type(tuple(fields))
+        except TypeError:
+            # A field spec that is not hashable: build it directly rather than failing.
+            return _make_struct_c_type(tuple(fields))
 
     def to_python(self, ctypes_object, **kwargs) -> Union[dict, OrderedDict]:
         result = self.dict_type()

--- a/pygridgain/datatypes/primitive_arrays.py
+++ b/pygridgain/datatypes/primitive_arrays.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import ctypes
+import struct
 import sys
 from io import SEEK_CUR
 
@@ -56,6 +57,40 @@ def _bulk_to_python(ctypes_object):
     return [ctypes_object.data[i] for i in range(ctypes_object.length)]
 
 
+def _bulk_from_python(cls, stream, value):
+    """
+    Encode a primitive array in one pass, or return False to use the element-wise path.
+
+    Encoding element by element costs one Python-level call per element. That is invisible for a
+    handful of values and dominant for a large one: a 1536-dimension embedding sent as a
+    vector-search clause spent ~1536 calls per query, which measured as the single largest component
+    of client-side CPU.
+
+    Both paths below are byte-for-byte identical to the element-wise one, on little- and big-endian
+    hosts alike: the ``struct`` formats are explicitly little-endian, matching
+    ``Primitive.from_python``, and the zero-copy path only triggers when the value's own dtype
+    already states little-endian.
+    """
+    # 1. zero copy — the buffer is already in wire layout (e.g. a numpy '<f4' array)
+    if cls._wire_dtype is not None:
+        dtype = getattr(value, 'dtype', None)
+        if dtype is not None and getattr(dtype, 'str', None) == cls._wire_dtype:
+            stream.write(value.tobytes())
+            return True
+
+    # 2. one pack call for the whole array
+    if cls._struct_format is not None:
+        try:
+            stream.write(struct.pack('<%d%s' % (len(value), cls._struct_format), *value))
+            return True
+        except (struct.error, TypeError, OverflowError):
+            # Not a plain sequence of in-range scalars. Fall back so the element-wise path raises
+            # the specific, familiar error rather than a bulk one.
+            pass
+
+    return False
+
+
 class PrimitiveArray(GridGainDataType):
     """
     Base class for array of primitives. Payload-only.
@@ -63,6 +98,13 @@ class PrimitiveArray(GridGainDataType):
     _type_name = None
     _type_id = None
     primitive_type = None
+
+    #: ``struct`` format character used to encode the whole array in one call. ``None`` keeps the
+    #: element-by-element path (types whose element encoding is not a plain little-endian scalar).
+    _struct_format = None
+
+    #: Buffer dtype string that already matches the wire layout exactly. ``None`` disables that path.
+    _wire_dtype = None
 
     @classmethod
     def build_c_type(cls, stream):
@@ -100,6 +142,10 @@ class PrimitiveArray(GridGainDataType):
     @classmethod
     def from_python(cls, stream, value, **kwargs):
         cls._write_header(stream, value)
+
+        if _bulk_from_python(cls, stream, value):
+            return
+
         for x in value:
             cls.primitive_type.from_python(stream, x)
 
@@ -125,6 +171,8 @@ class ShortArray(PrimitiveArray):
     _type_id = TYPE_SHORT_ARR
     primitive_type = Short
     type_code = TC_SHORT_ARRAY
+    _struct_format = 'h'
+    _wire_dtype = '<i2'
 
 
 class IntArray(PrimitiveArray):
@@ -132,6 +180,8 @@ class IntArray(PrimitiveArray):
     _type_id = TYPE_INT_ARR
     primitive_type = Int
     type_code = TC_INT_ARRAY
+    _struct_format = 'i'
+    _wire_dtype = '<i4'
 
 
 class LongArray(PrimitiveArray):
@@ -139,6 +189,8 @@ class LongArray(PrimitiveArray):
     _type_id = TYPE_LONG_ARR
     primitive_type = Long
     type_code = TC_LONG_ARRAY
+    _struct_format = 'q'
+    _wire_dtype = '<i8'
 
 
 class FloatArray(PrimitiveArray):
@@ -146,6 +198,8 @@ class FloatArray(PrimitiveArray):
     _type_id = TYPE_FLOAT_ARR
     primitive_type = Float
     type_code = TC_FLOAT_ARRAY
+    _struct_format = 'f'
+    _wire_dtype = '<f4'
 
 
 class DoubleArray(PrimitiveArray):
@@ -153,6 +207,8 @@ class DoubleArray(PrimitiveArray):
     _type_id = TYPE_DOUBLE_ARR
     primitive_type = Double
     type_code = TC_DOUBLE_ARRAY
+    _struct_format = 'd'
+    _wire_dtype = '<f8'
 
 
 class CharArray(PrimitiveArray):
@@ -179,6 +235,15 @@ class PrimitiveArrayObject(Nullable):
     type_code = None
     pythonic = list
     default = []
+
+    #: ``struct`` format character used to encode the whole array in one call. ``None`` keeps the
+    #: element-by-element path (types whose element encoding is not a plain little-endian scalar).
+    _struct_format = None
+
+    #: Buffer dtype string that already matches the wire layout exactly. When the value reports this
+    #: dtype, its bytes are written straight through with no per-element work at all. ``None``
+    #: disables that path.
+    _wire_dtype = None
 
     @classmethod
     def build_c_type(cls, stream):
@@ -213,6 +278,10 @@ class PrimitiveArrayObject(Nullable):
     @classmethod
     def from_python_not_null(cls, stream, value, **kwargs):
         cls._write_header(stream, value)
+
+        if _bulk_from_python(cls, stream, value):
+            return
+
         for x in value:
             cls.primitive_type.from_python(stream, x)
 
@@ -263,6 +332,8 @@ class ShortArrayObject(PrimitiveArrayObject):
     _type_id = TYPE_SHORT_ARR
     primitive_type = Short
     type_code = TC_SHORT_ARRAY
+    _struct_format = 'h'
+    _wire_dtype = '<i2'
 
 
 class IntArrayObject(PrimitiveArrayObject):
@@ -270,6 +341,8 @@ class IntArrayObject(PrimitiveArrayObject):
     _type_id = TYPE_INT_ARR
     primitive_type = Int
     type_code = TC_INT_ARRAY
+    _struct_format = 'i'
+    _wire_dtype = '<i4'
 
 
 class LongArrayObject(PrimitiveArrayObject):
@@ -277,6 +350,8 @@ class LongArrayObject(PrimitiveArrayObject):
     _type_id = TYPE_LONG_ARR
     primitive_type = Long
     type_code = TC_LONG_ARRAY
+    _struct_format = 'q'
+    _wire_dtype = '<i8'
 
 
 class FloatArrayObject(PrimitiveArrayObject):
@@ -284,6 +359,8 @@ class FloatArrayObject(PrimitiveArrayObject):
     _type_id = TYPE_FLOAT_ARR
     primitive_type = Float
     type_code = TC_FLOAT_ARRAY
+    _struct_format = 'f'
+    _wire_dtype = '<f4'
 
 
 class DoubleArrayObject(PrimitiveArrayObject):
@@ -291,6 +368,8 @@ class DoubleArrayObject(PrimitiveArrayObject):
     _type_id = TYPE_DOUBLE_ARR
     primitive_type = Double
     type_code = TC_DOUBLE_ARRAY
+    _struct_format = 'd'
+    _wire_dtype = '<f8'
 
 
 class CharArrayObject(PrimitiveArrayObject):

--- a/pygridgain/datatypes/standard.py
+++ b/pygridgain/datatypes/standard.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import ctypes
+import functools
 from datetime import date, datetime, time, timedelta
 import decimal
 from io import SEEK_CUR
@@ -60,6 +61,24 @@ class StandardObject(Nullable):
         return data_type
 
 
+@functools.lru_cache(maxsize=1024)
+def _cached_string_c_type(cls, length: int):
+    """One ctypes Structure per (string type, length). Bounded: string lengths vary, so this is a
+    cache rather than a table, and eviction is fine — a miss just rebuilds the class."""
+    return type(
+        cls.__name__,
+        (ctypes.LittleEndianStructure,),
+        {
+            '_pack_': 1,
+            '_fields_': [
+                ('type_code', ctypes.c_byte),
+                ('length', ctypes.c_int),
+                ('data', ctypes.c_char * length),
+            ],
+        },
+    )
+
+
 class String(Nullable):
     """
     Pascal-style string: `c_int` counter, followed by count*bytes.
@@ -76,18 +95,10 @@ class String(Nullable):
 
     @classmethod
     def build_c_type(cls, length: int):
-        return type(
-            cls.__name__,
-            (ctypes.LittleEndianStructure,),
-            {
-                '_pack_': 1,
-                '_fields_': [
-                    ('type_code', ctypes.c_byte),
-                    ('length', ctypes.c_int),
-                    ('data', ctypes.c_char * length),
-                ],
-            },
-        )
+        # Memoized for the same reason as Struct.build_c_type: one class creation per string field
+        # per response, all identical for a given length. Keyed on the class too, since subclasses
+        # inherit this and the generated class takes its name from cls.
+        return _cached_string_c_type(cls, length)
 
     @classmethod
     def parse_not_null(cls, stream):

--- a/tests/test_c_type_cache.py
+++ b/tests/test_c_type_cache.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2026 GridGain Systems, Inc. and Contributors.
+#
+# Licensed under the GridGain Community Edition License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Server-free coverage for ctypes-class memoization in the response path.
+
+Building a ctypes Structure calls ``type()``, which allocates a class and computes a struct layout.
+The parser built one per row, all identical — for a k-NN query returning 10 ids that was 10 class
+creations per query. These classes are only ever read (``sizeof``, ``from_buffer_copy``,
+``read_ctype``), never mutated, so one shared class per shape is safe.
+
+What must hold, and is asserted here: identical shapes share a class, different shapes never do,
+layouts are unchanged, and an unusable field spec still raises rather than being cached.
+"""
+import ctypes
+
+import pytest
+
+from pygridgain.datatypes.internal import Struct, _cached_struct_c_type
+from pygridgain.datatypes.standard import String
+
+FIELDS = [('length', ctypes.c_int), ('type_code', ctypes.c_byte), ('data', ctypes.c_byte * 16)]
+OTHER = [('length', ctypes.c_int), ('data', ctypes.c_byte * 32)]
+
+
+def test_same_shape_returns_the_same_class():
+    # A fresh list with equal contents must still hit: the key is the shape, not the list identity.
+    assert Struct.build_c_type(FIELDS) is Struct.build_c_type(list(FIELDS))
+
+
+def test_different_shapes_do_not_collide():
+    assert Struct.build_c_type(FIELDS) is not Struct.build_c_type(OTHER)
+
+
+def test_layout_is_unchanged():
+    c = Struct.build_c_type(FIELDS)
+    assert ctypes.sizeof(c) == ctypes.sizeof(ctypes.c_int) + ctypes.sizeof(ctypes.c_byte) + 16
+    assert [n for n, _ in c._fields_] == ['length', 'type_code', 'data']
+
+
+def test_instances_are_independent_even_though_the_class_is_shared():
+    """Sharing the class must not share state — the whole point is that only the type is reused."""
+    c = Struct.build_c_type(FIELDS)
+    a, b = c(), c()
+    a.length = 7
+    b.length = 9
+    assert (a.length, b.length) == (7, 9)
+
+
+def test_cache_actually_hits():
+    Struct.build_c_type(FIELDS)
+    before = _cached_struct_c_type.cache_info().hits
+    for _ in range(50):
+        Struct.build_c_type(list(FIELDS))
+    assert _cached_struct_c_type.cache_info().hits >= before + 50
+
+
+def test_unusable_field_spec_still_raises():
+    """An unhashable spec must not be silently swallowed by the cache lookup."""
+    with pytest.raises(TypeError):
+        Struct.build_c_type([('x', ctypes.c_int), ('bad', [1, 2, 3])])
+
+
+def test_string_c_type_is_memoized_per_length():
+    assert String.build_c_type(12) is String.build_c_type(12)
+    assert String.build_c_type(12) is not String.build_c_type(24)
+    assert ctypes.sizeof(String.build_c_type(24)) - ctypes.sizeof(String.build_c_type(12)) == 12
+
+
+def test_string_subclasses_do_not_share_a_class():
+    """The generated class takes its name from cls, so the cache key includes the class."""
+    class Derived(String):
+        pass
+
+    assert String.build_c_type(8) is not Derived.build_c_type(8)
+    assert Derived.build_c_type(8).__name__ == 'Derived'

--- a/tests/test_primitive_arrays.py
+++ b/tests/test_primitive_arrays.py
@@ -118,3 +118,93 @@ def test_bulk_decode_matches_elementwise_and_big_endian_fallback(monkeypatch):
     monkeypatch.setattr(sys, 'byteorder', 'big')   # force the element-wise fallback branch
     fallback = _bulk_to_python(ctypes_object)
     assert fallback == reference == value
+
+
+# ---------------------------------------------------------------------------
+# Bulk SERIALIZATION fast path (_bulk_from_python) — the encode counterpart of
+# the decode coverage above. The element-wise path is the reference: every fast
+# path must be byte-for-byte identical to it, because these bytes go on the wire.
+# ---------------------------------------------------------------------------
+
+BULK_ENCODE_TYPES = [
+    ShortArrayObject, IntArrayObject, LongArrayObject, FloatArrayObject, DoubleArrayObject,
+    ShortArray, IntArray, LongArray, FloatArray, DoubleArray,
+]
+
+
+def _serialize_elementwise(datatype, value, monkeypatch):
+    """Serialize with both fast paths disabled, i.e. one call per element."""
+    monkeypatch.setattr(datatype, '_struct_format', None)
+    monkeypatch.setattr(datatype, '_wire_dtype', None)
+    try:
+        return _serialize(datatype, value)
+    finally:
+        monkeypatch.undo()
+
+
+# Deliberately includes the values most likely to expose an encoding difference:
+# type extremes, signed zero, subnormals, and the non-finite floats.
+EDGE_CASES = [
+    (ShortArrayObject, [0, 1, -1, 32767, -32768]),
+    (IntArrayObject, [0, 1, -1, 2 ** 31 - 1, -2 ** 31]),
+    (LongArrayObject, [0, 1, -1, 2 ** 63 - 1, -2 ** 63]),
+    (FloatArrayObject, [0.0, -0.0, 1.5, -1.5, 3.4e38, -3.4e38, 1e-45,
+                        float('inf'), float('-inf'), float('nan')]),
+    (DoubleArrayObject, [0.0, -0.0, 1.5, -1.5, 1.7e308, 5e-324,
+                         float('inf'), float('-inf'), float('nan')]),
+]
+
+
+@pytest.mark.parametrize('datatype,value', EDGE_CASES)
+def test_bulk_encode_is_byte_identical(datatype, value, monkeypatch):
+    assert _serialize(datatype, value) == _serialize_elementwise(datatype, value, monkeypatch)
+
+
+@pytest.mark.parametrize('datatype,value', EDGE_CASES)
+def test_bulk_encode_accepts_tuples(datatype, value, monkeypatch):
+    assert _serialize(datatype, tuple(value)) == _serialize_elementwise(datatype, value, monkeypatch)
+
+
+@pytest.mark.parametrize('datatype', BULK_ENCODE_TYPES)
+def test_bulk_encode_empty(datatype, monkeypatch):
+    assert _serialize(datatype, []) == _serialize_elementwise(datatype, [], monkeypatch)
+
+
+def test_bulk_encode_large_vector_is_byte_identical(monkeypatch):
+    """The motivating case: a 1536-d embedding sent as a vector-search clause."""
+    value = [i * 0.5 for i in range(1536)]
+    assert _serialize(FloatArrayObject, value) == _serialize_elementwise(FloatArrayObject, value, monkeypatch)
+
+
+def test_char_and_bool_keep_the_elementwise_path():
+    """Char encodes through a text codec and Bool has its own byte semantics."""
+    for datatype in (CharArrayObject, BoolArrayObject):
+        assert datatype._struct_format is None
+        assert datatype._wire_dtype is None
+
+
+def test_bad_element_still_raises():
+    """A non-numeric element must fail, not be silently coerced by the bulk path."""
+    with pytest.raises(Exception):
+        _serialize(IntArrayObject, [1, 'not a number', 3])
+
+
+def test_zero_copy_path_matches_and_only_takes_matching_dtype(monkeypatch):
+    """A buffer already in wire layout is written straight through; anything else is not."""
+    numpy = pytest.importorskip('numpy')
+    value = [0.0, 1.5, -2.25, 1024.0, float('nan')]
+
+    reference = _serialize_elementwise(FloatArrayObject, value, monkeypatch)
+
+    little = numpy.asarray(value, dtype='<f4')
+    assert little.dtype.str == FloatArrayObject._wire_dtype
+    assert _serialize(FloatArrayObject, little) == reference
+
+    # A byte-swapped buffer must NOT take the zero-copy path, or the wire bytes would be reversed.
+    big = numpy.asarray(value, dtype='>f4')
+    assert big.dtype.str != FloatArrayObject._wire_dtype
+    assert _serialize(FloatArrayObject, big) == reference
+
+    # float64 input to a float32 field must still narrow correctly rather than copy raw bytes.
+    wide = numpy.asarray(value, dtype='<f8')
+    assert _serialize(FloatArrayObject, wide) == reference


### PR DESCRIPTION
[GG-50683](https://ggsystems.atlassian.net/browse/GG-50683)

Sending a primitive array cost **one Python-level call per element**. For a 1536-dimension embedding passed as a vector-search clause that is ~1536 calls per query, and it measured as the largest single component of client-side CPU. [GG-49287](https://ggsystems.atlassian.net/browse/GG-49287) (#79) bulk-optimised only the *decode* side, so the send path was left behind.

## What changed

**Encode the whole array in one pass** (`pygridgain/datatypes/primitive_arrays.py`):

- one `struct.pack` call for `Short`/`Int`/`Long`/`Float`/`Double` arrays, and
- a **zero-copy write** when the value's own dtype already matches the wire layout — e.g. a numpy `'<f4'` embedding — skipping per-element work entirely.

Applied to both `PrimitiveArray.from_python` and `PrimitiveArrayObject.from_python_not_null`.

**Memoize the two ctypes class builders** that surfaced next, once encoding was no longer dominant. `Struct.build_c_type` and `String.build_c_type` each call `type()` to allocate a class and compute a struct layout, and a response with N rows built N identical ones — for a k-NN query returning 10 ids, 10 class creations per query. Both results are only ever read (`sizeof`, `from_buffer_copy`, `read_ctype`), never mutated, so a bounded `lru_cache` keyed on the shape is safe.

## Correctness

**Byte-for-byte identical to the element-wise encoding, on little- and big-endian hosts alike.** The `struct` formats are explicitly little-endian, matching `Primitive.from_python`, and the zero-copy path only triggers when the value's dtype already states little-endian — a `'>f4'` array takes the pack path, not the passthrough.

- **`Char` and `Bool` keep the element-wise path** — their element encoding is not a plain little-endian scalar.
- Any value that is not a sequence of in-range scalars **falls back**, so the familiar per-element error is what gets raised, not a bulk one.
- `String` memoization is keyed on `cls` as well as length, since subclasses inherit the builder and the generated class takes its name from `cls`.

## Measured

Controlled A/B on the benchmark VM, 100k x 1536-d cosine dbpedia-openai corpus:

| | |
|---|---|
| client p50 | **1.31x** |
| client CPU | **-56%** |

For context, client CPU is 28% of the end-to-end gap against RediSearch at matched recall — the rest is server-side and tracked separately.

## Tests

`tests/test_primitive_arrays.py` (+90) and a new `tests/test_c_type_cache.py` — **59 pass**, server-free. Coverage: byte-identical output per array type, empty arrays, the 1536-d vector, the big-endian fallback, `Char`/`Bool` staying on the element path, bad elements still raising, the zero-copy path only accepting a matching dtype, and for the caches: same shape returns the same class, different shapes don't collide, layout unchanged, instances stay independent despite the shared class, the cache actually hits, and an unhashable field spec still builds.


[GG-50683]: https://ggsystems.atlassian.net/browse/GG-50683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GG-49287]: https://ggsystems.atlassian.net/browse/GG-49287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ