### PR TITLE
GG-49543 Adopt per-index HNSW build parameters (feature bit 38)

### DIFF
--- a/docs/datatypes/cache_props.rst
+++ b/docs/datatypes/cache_props.rst
@@ -146,6 +146,21 @@ Query index
 - `inline_size`: integer value,
 - `fields`: a list of 0 or more indexed fields (see `Fields`_).
 
+The remaining keys apply to vector indexes only (`index_type` = 3). They are sent only when
+the cluster supports them, and are ignored on any other index type:
+
+- `similarity_function`: (optional) vector similarity function as an integer value.
+  Defaults to 0. Requires a cluster supporting vector similarity functions,
+- `hnsw_m`: (optional) number of HNSW graph connections per node, 1 to 512. Defaults to 0,
+  which lets the vector engine choose. Changing it requires an index rebuild,
+- `hnsw_ef_construction`: (optional) HNSW build-time beam width, 1 to 3200. Defaults to 0,
+  which lets the vector engine choose. Changing it requires an index rebuild.
+
+Setting `hnsw_m` or `hnsw_ef_construction` against a cluster that does not support per-index
+HNSW build parameters raises `NotSupportedByClusterError` rather than silently building a
+graph with different parameters than requested. A cluster that does not send these values
+back omits the keys entirely from the index it returns.
+
 Fields
 ======
 

--- a/pygridgain/connection/bitmask_feature.py
+++ b/pygridgain/connection/bitmask_feature.py
@@ -24,6 +24,7 @@ class BitmaskFeature(IntFlag):
     CLUSTER_API = 1 << 2
     QUERY_INDEX_VECTOR_SIMILARITY = 1 << 33
     QUERY_VECTOR_EXTENDED = 1 << 35
+    QUERY_INDEX_VECTOR_HNSW_PARAMS = 1 << 38
 
     def __bytes__(self) -> bytes:
         """

--- a/pygridgain/connection/protocol_context.py
+++ b/pygridgain/connection/protocol_context.py
@@ -120,7 +120,7 @@ class ProtocolContext:
         Check whether cluster API supported by the current protocol.
         """
         return self.features and BitmaskFeature.CLUSTER_API in self.features
-    
+
     def is_query_index_vector_similarity_supported(self) -> bool:
         """
         Check whether query index vector similarity supported by the current protocol.
@@ -133,6 +133,13 @@ class ProtocolContext:
         by the cluster.
         """
         return self.features and BitmaskFeature.QUERY_VECTOR_EXTENDED in self.features
+
+    def is_query_index_vector_hnsw_params_supported(self) -> bool:
+        """
+        Check whether per-index HNSW build parameters (hnswM, hnswEfConstruction) are
+        supported by the current protocol.
+        """
+        return self.features and BitmaskFeature.QUERY_INDEX_VECTOR_HNSW_PARAMS in self.features
 
     def is_expiry_policy_supported(self) -> bool:
         return self.version >= (1, 6, 0)

--- a/pygridgain/datatypes/cache_config.py
+++ b/pygridgain/datatypes/cache_config.py
@@ -13,8 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
+import ctypes
 from functools import lru_cache
+from io import SEEK_CUR
 
+import attr
+
+from pygridgain.constants import PROTOCOL_BYTE_ORDER
+from ..stream import READ_BACKWARD
 from . import ExpiryPolicy
 from .standard import String
 from .internal import AnyDataObject, Struct, StructArray
@@ -110,13 +117,115 @@ Fields = StructArray([
 })
 
 
-def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> StructArray:
+@attr.s
+class QueryIndexArray(StructArray):
+    """
+    Query indexes, whose trailing fields belong to VECTOR indexes only.
+
+    The server appends ``similarity_function`` and the HNSW build parameters to an index only
+    when the matching feature bit was negotiated **and** that index is a VECTOR index, so the
+    element layout varies within one array. A flat layout breaks both directions: writing the
+    fields on a non-VECTOR index leaves bytes the server never reads, and parsing them where
+    the server never wrote them consumes the head of the next index — which then yields an
+    absurd field count rather than an error.
+    """
+
+    #: Names the server writes for VECTOR indexes only, in wire order.
+    vector_only = attr.ib(type=tuple, default=())
+
+    def _following_for(self, index_type) -> list:
+        if index_type == IndexType.VECTOR:
+            return self.following
+        return [(name, el) for name, el in self.following if name not in self.vector_only]
+
+    def _apply_defaults(self, value) -> list:
+        following = self._following_for(value.get('index_type'))
+        for name, _ in following:
+            if name in self.defaults:
+                value.setdefault(name, self.defaults[name])
+        return following
+
+    def _write_length(self, stream, length):
+        stream.write(length.to_bytes(ctypes.sizeof(self.counter_type), byteorder=PROTOCOL_BYTE_ORDER))
+
+    def _read_length(self, stream):
+        counter_sz = ctypes.sizeof(self.counter_type)
+        length = int.from_bytes(stream.slice(offset=counter_sz), byteorder=PROTOCOL_BYTE_ORDER)
+        stream.seek(counter_sz, SEEK_CUR)
+        return [('length', self.counter_type)], length
+
+    def _element_following(self, element) -> list:
+        present = {field[0] for field in element._fields_}
+        return [(name, el) for name, el in self.following if name in present]
+
+    def from_python(self, stream, value):
+        self._write_length(stream, len(value))
+
+        for v in value:
+            for name, el_class in self._apply_defaults(v):
+                el_class.from_python(stream, v[name])
+
+    async def from_python_async(self, stream, value):
+        self._write_length(stream, len(value))
+
+        for v in value:
+            for name, el_class in self._apply_defaults(v):
+                await el_class.from_python_async(stream, v[name])
+
+    def parse(self, stream):
+        fields, length = self._read_length(stream)
+
+        for i in range(length):
+            el_fields, index_type = [], None
+            for name, el_class in self.following:
+                if name in self.vector_only and index_type != IndexType.VECTOR:
+                    continue
+                c_type = el_class.parse(stream)
+                el_fields.append((name, c_type))
+                if name == 'index_type':
+                    index_type = stream.read_ctype(c_type, direction=READ_BACKWARD).value
+            fields.append((f'element_{i}', Struct.build_c_type(el_fields)))
+
+        return self.build_c_type(fields)
+
+    async def parse_async(self, stream):
+        fields, length = self._read_length(stream)
+
+        for i in range(length):
+            el_fields, index_type = [], None
+            for name, el_class in self.following:
+                if name in self.vector_only and index_type != IndexType.VECTOR:
+                    continue
+                c_type = await el_class.parse_async(stream)
+                el_fields.append((name, c_type))
+                if name == 'index_type':
+                    index_type = stream.read_ctype(c_type, direction=READ_BACKWARD).value
+            fields.append((f'element_{i}', Struct.build_c_type(el_fields)))
+
+        return self.build_c_type(fields)
+
+    def to_python(self, ctypes_object, **kwargs):
+        length = getattr(ctypes_object, 'length', 0)
+        return [
+            Struct(self._element_following(el), dict_type=dict).to_python(el, **kwargs)
+            for el in (getattr(ctypes_object, f'element_{i}') for i in range(length))
+        ]
+
+    async def to_python_async(self, ctypes_object, **kwargs):
+        length = getattr(ctypes_object, 'length', 0)
+        result_coro = [
+            Struct(self._element_following(el), dict_type=dict).to_python_async(el, **kwargs)
+            for el in (getattr(ctypes_object, f'element_{i}') for i in range(length))
+        ]
+        return await asyncio.gather(*result_coro)
+
+
+def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> QueryIndexArray:
     """
     Build the query index layout that the negotiated protocol actually puts on the wire.
 
-    The server appends ``similarity_function`` and the two HNSW build parameters to a query
-    index only when the matching feature bit was negotiated, so this layout has to track the
-    negotiated set exactly: one field too many or too few desynchronises the whole stream.
+    Which trailing fields exist at all is decided by the negotiated feature bits; whether a
+    given index carries them is decided per index by :class:`QueryIndexArray`.
     """
     following = [
         ('index_name', String),
@@ -125,18 +234,21 @@ def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> StructArray:
         ('fields', Fields),
     ]
     defaults = {}
+    vector_only = []
 
     if has_similarity:
         following.append(('similarity_function', Int))
         defaults['similarity_function'] = 0
+        vector_only.append('similarity_function')
 
     if has_hnsw_params:
         following.append(('hnsw_m', Int))
         following.append(('hnsw_ef_construction', Int))
         defaults['hnsw_m'] = HNSW_ENGINE_DEFAULT
         defaults['hnsw_ef_construction'] = HNSW_ENGINE_DEFAULT
+        vector_only.extend(('hnsw_m', 'hnsw_ef_construction'))
 
-    return StructArray(following, defaults=defaults)
+    return QueryIndexArray(following, defaults=defaults, vector_only=tuple(vector_only))
 
 
 @lru_cache(maxsize=None)

--- a/pygridgain/datatypes/cache_config.py
+++ b/pygridgain/datatypes/cache_config.py
@@ -133,28 +133,42 @@ class QueryIndexArray(StructArray):
     #: Names the server writes for VECTOR indexes only, in wire order.
     vector_only = attr.ib(type=tuple, default=())
 
-    #: ``(name, unset_value)`` pairs this negotiated layout cannot carry at all. Asking for
-    #: one of them is refused rather than dropped: silently building a graph the caller did
-    #: not ask for is worse than failing.
-    unsupported = attr.ib(type=tuple, default=())
+    #: ``(name, unset_value)`` pairs for the HNSW build parameters. Known whatever the
+    #: negotiated layout is, so that asking for one where it cannot apply is reported rather
+    #: than dropped: silently building a graph the caller did not ask for is worse than
+    #: failing, and a dropped parameter is invisible until someone measures recall.
+    hnsw_params = attr.ib(type=tuple, default=())
+
+    #: Whether the negotiated protocol can carry :attr:`hnsw_params` at all.
+    hnsw_supported = attr.ib(type=bool, default=False)
 
     def _following_for(self, index_type) -> list:
         if index_type == IndexType.VECTOR:
             return self.following
         return [(name, el) for name, el in self.following if name not in self.vector_only]
 
-    def _reject_unsupported(self, value):
-        if value.get('index_type') != IndexType.VECTOR:
+    def _validate(self, value):
+        configured = [(name, value[name]) for name, unset in self.hnsw_params
+                      if value.get(name, unset) != unset]
+
+        if not configured:
             return
-        for name, unset in self.unsupported:
-            if value.get(name, unset) != unset:
-                raise NotSupportedByClusterError(
-                    f'The cluster does not support per-index HNSW build parameters '
-                    f'({name}={value[name]} on index {value.get("index_name")!r})'
-                )
+
+        name, val = configured[0]
+        where = f'({name}={val} on index {value.get("index_name")!r})'
+
+        if value.get('index_type') != IndexType.VECTOR:
+            # The server refuses this outright (QueryUtils.validateHnswParams); the wire
+            # format gives it nowhere to go, so without this it would vanish silently.
+            raise ValueError(f'HNSW build parameters are supported by VECTOR indexes only {where}')
+
+        if not self.hnsw_supported:
+            raise NotSupportedByClusterError(
+                f'The cluster does not support per-index HNSW build parameters {where}'
+            )
 
     def _prepare(self, value) -> list:
-        self._reject_unsupported(value)
+        self._validate(value)
         following = self._following_for(value.get('index_type'))
         for name, _ in following:
             if name in self.defaults:
@@ -246,7 +260,6 @@ def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> QueryIndexArr
     ]
     defaults = {}
     vector_only = []
-    unsupported = ()
 
     if has_similarity:
         following.append(('similarity_function', Int))
@@ -259,12 +272,15 @@ def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> QueryIndexArr
         defaults['hnsw_m'] = HNSW_ENGINE_DEFAULT
         defaults['hnsw_ef_construction'] = HNSW_ENGINE_DEFAULT
         vector_only.extend(('hnsw_m', 'hnsw_ef_construction'))
-    else:
-        unsupported = (('hnsw_m', HNSW_ENGINE_DEFAULT),
-                       ('hnsw_ef_construction', HNSW_ENGINE_DEFAULT))
 
-    return QueryIndexArray(following, defaults=defaults,
-                           vector_only=tuple(vector_only), unsupported=unsupported)
+    return QueryIndexArray(
+        following,
+        defaults=defaults,
+        vector_only=tuple(vector_only),
+        hnsw_params=(('hnsw_m', HNSW_ENGINE_DEFAULT),
+                     ('hnsw_ef_construction', HNSW_ENGINE_DEFAULT)),
+        hnsw_supported=has_hnsw_params,
+    )
 
 
 @lru_cache(maxsize=None)

--- a/pygridgain/datatypes/cache_config.py
+++ b/pygridgain/datatypes/cache_config.py
@@ -14,13 +14,11 @@
 # limitations under the License.
 #
 import asyncio
-import ctypes
 from functools import lru_cache
-from io import SEEK_CUR
 
 import attr
 
-from pygridgain.constants import PROTOCOL_BYTE_ORDER
+from pygridgain.exceptions import NotSupportedByClusterError, ParseError
 from ..stream import READ_BACKWARD
 from . import ExpiryPolicy
 from .standard import String
@@ -37,14 +35,16 @@ __all__ = [
 
 
 #: Leaving an HNSW build parameter at this value lets the vector engine choose it. Mirrors
-#: ``QueryIndex.HNSW_ENGINE_DEFAULT`` on the server, and is what an index serialized before
-#: these parameters existed deserializes to — which is what makes zero mean "unset".
+#: ``QueryIndex.HNSW_ENGINE_DEFAULT`` on the server. Note that an index read back from a
+#: cluster that does not send these parameters has the keys *absent* from its dict rather
+#: than set to this value.
 HNSW_ENGINE_DEFAULT = 0
 
-#: Largest number of graph connections per node the vector engine accepts.
+#: Largest number of graph connections per node the vector engine accepts. Enforced by the
+#: server (QueryUtils.validateHnswParams); mirrored here so callers can validate up front.
 MAX_HNSW_M = 512
 
-#: Largest build-time beam width the vector engine accepts.
+#: Largest build-time beam width the vector engine accepts. Server-enforced, as above.
 MAX_HNSW_EF_CONSTRUCTION = 3200
 
 
@@ -133,47 +133,58 @@ class QueryIndexArray(StructArray):
     #: Names the server writes for VECTOR indexes only, in wire order.
     vector_only = attr.ib(type=tuple, default=())
 
+    #: ``(name, unset_value)`` pairs this negotiated layout cannot carry at all. Asking for
+    #: one of them is refused rather than dropped: silently building a graph the caller did
+    #: not ask for is worse than failing.
+    unsupported = attr.ib(type=tuple, default=())
+
     def _following_for(self, index_type) -> list:
         if index_type == IndexType.VECTOR:
             return self.following
         return [(name, el) for name, el in self.following if name not in self.vector_only]
 
-    def _apply_defaults(self, value) -> list:
+    def _reject_unsupported(self, value):
+        if value.get('index_type') != IndexType.VECTOR:
+            return
+        for name, unset in self.unsupported:
+            if value.get(name, unset) != unset:
+                raise NotSupportedByClusterError(
+                    f'The cluster does not support per-index HNSW build parameters '
+                    f'({name}={value[name]} on index {value.get("index_name")!r})'
+                )
+
+    def _prepare(self, value) -> list:
+        self._reject_unsupported(value)
         following = self._following_for(value.get('index_type'))
         for name, _ in following:
             if name in self.defaults:
                 value.setdefault(name, self.defaults[name])
         return following
 
-    def _write_length(self, stream, length):
-        stream.write(length.to_bytes(ctypes.sizeof(self.counter_type), byteorder=PROTOCOL_BYTE_ORDER))
-
-    def _read_length(self, stream):
-        counter_sz = ctypes.sizeof(self.counter_type)
-        length = int.from_bytes(stream.slice(offset=counter_sz), byteorder=PROTOCOL_BYTE_ORDER)
-        stream.seek(counter_sz, SEEK_CUR)
-        return [('length', self.counter_type)], length
-
     def _element_following(self, element) -> list:
-        present = {field[0] for field in element._fields_}
-        return [(name, el) for name, el in self.following if name in present]
+        known = {name for name, _ in self.following}
+        present = [field[0] for field in element._fields_]
+        unknown = [name for name in present if name not in known]
+        if unknown:
+            raise ParseError(f'Parsed query index carries unknown fields: {unknown}')
+        return [(name, el) for name, el in self.following if name in set(present)]
 
     def from_python(self, stream, value):
-        self._write_length(stream, len(value))
+        self._write_header(stream, len(value))
 
         for v in value:
-            for name, el_class in self._apply_defaults(v):
+            for name, el_class in self._prepare(v):
                 el_class.from_python(stream, v[name])
 
     async def from_python_async(self, stream, value):
-        self._write_length(stream, len(value))
+        self._write_header(stream, len(value))
 
         for v in value:
-            for name, el_class in self._apply_defaults(v):
+            for name, el_class in self._prepare(v):
                 await el_class.from_python_async(stream, v[name])
 
     def parse(self, stream):
-        fields, length = self._read_length(stream)
+        fields, length = self._parse_header(stream)
 
         for i in range(length):
             el_fields, index_type = [], None
@@ -189,7 +200,7 @@ class QueryIndexArray(StructArray):
         return self.build_c_type(fields)
 
     async def parse_async(self, stream):
-        fields, length = self._read_length(stream)
+        fields, length = self._parse_header(stream)
 
         for i in range(length):
             el_fields, index_type = [], None
@@ -235,6 +246,7 @@ def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> QueryIndexArr
     ]
     defaults = {}
     vector_only = []
+    unsupported = ()
 
     if has_similarity:
         following.append(('similarity_function', Int))
@@ -247,8 +259,12 @@ def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> QueryIndexArr
         defaults['hnsw_m'] = HNSW_ENGINE_DEFAULT
         defaults['hnsw_ef_construction'] = HNSW_ENGINE_DEFAULT
         vector_only.extend(('hnsw_m', 'hnsw_ef_construction'))
+    else:
+        unsupported = (('hnsw_m', HNSW_ENGINE_DEFAULT),
+                       ('hnsw_ef_construction', HNSW_ENGINE_DEFAULT))
 
-    return QueryIndexArray(following, defaults=defaults, vector_only=tuple(vector_only))
+    return QueryIndexArray(following, defaults=defaults,
+                           vector_only=tuple(vector_only), unsupported=unsupported)
 
 
 @lru_cache(maxsize=None)
@@ -276,15 +292,13 @@ def query_entities_for(protocol_context) -> StructArray:
     Pick the query entities layout matching what this connection negotiated.
     """
     return query_entities_struct(
-        bool(protocol_context and protocol_context.is_query_index_vector_similarity_supported()),
-        bool(protocol_context and protocol_context.is_query_index_vector_hnsw_params_supported()),
+        bool(protocol_context.is_query_index_vector_similarity_supported()),
+        bool(protocol_context.is_query_index_vector_hnsw_params_supported()),
     )
 
 
-# Named layouts for the combinations that predate the HNSW build parameters. Kept because
-# they are imported elsewhere in the package and read more clearly than a flag pair.
-QueryIndexes = _query_indexes(True, False)
-QueryIndexesNoSimilarity = _query_indexes(False, False)
+# The two layouts that predate the HNSW build parameters, named because cache_properties
+# binds them to its query entities properties.
 QueryEntities = query_entities_struct(True, False)
 QueryEntitiesNoSimilarity = query_entities_struct(False, False)
 

--- a/pygridgain/datatypes/cache_config.py
+++ b/pygridgain/datatypes/cache_config.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from functools import lru_cache
+
 from . import ExpiryPolicy
 from .standard import String
 from .internal import AnyDataObject, Struct, StructArray
@@ -22,8 +24,21 @@ from .primitive import *
 __all__ = [
     'get_cache_config_struct', 'CacheMode', 'PartitionLossPolicy',
     'RebalanceMode', 'WriteSynchronizationMode', 'IndexType',
-    'CacheAtomicityMode'
+    'CacheAtomicityMode', 'HNSW_ENGINE_DEFAULT', 'MAX_HNSW_M',
+    'MAX_HNSW_EF_CONSTRUCTION'
 ]
+
+
+#: Leaving an HNSW build parameter at this value lets the vector engine choose it. Mirrors
+#: ``QueryIndex.HNSW_ENGINE_DEFAULT`` on the server, and is what an index serialized before
+#: these parameters existed deserializes to — which is what makes zero mean "unset".
+HNSW_ENGINE_DEFAULT = 0
+
+#: Largest number of graph connections per node the vector engine accepts.
+MAX_HNSW_M = 512
+
+#: Largest build-time beam width the vector engine accepts.
+MAX_HNSW_EF_CONSTRUCTION = 3200
 
 
 class CacheMode(Int):
@@ -95,44 +110,71 @@ Fields = StructArray([
 })
 
 
-QueryIndexes = StructArray([
-    ('index_name', String),
-    ('index_type', IndexType),
-    ('inline_size', Int),
-    ('fields', Fields),
-    ('similarity_function', Int),
-], defaults={
-    'similarity_function': 0,
-})
+def _query_indexes(has_similarity: bool, has_hnsw_params: bool) -> StructArray:
+    """
+    Build the query index layout that the negotiated protocol actually puts on the wire.
 
-QueryIndexesNoSimilarity = StructArray([
-    ('index_name', String),
-    ('index_type', IndexType),
-    ('inline_size', Int),
-    ('fields', Fields),
-])
+    The server appends ``similarity_function`` and the two HNSW build parameters to a query
+    index only when the matching feature bit was negotiated, so this layout has to track the
+    negotiated set exactly: one field too many or too few desynchronises the whole stream.
+    """
+    following = [
+        ('index_name', String),
+        ('index_type', IndexType),
+        ('inline_size', Int),
+        ('fields', Fields),
+    ]
+    defaults = {}
 
-QueryEntities = StructArray([
-    ('key_type_name', String),
-    ('value_type_name', String),
-    ('table_name', String),
-    ('key_field_name', String),
-    ('value_field_name', String),
-    ('query_fields', QueryFields),
-    ('field_name_aliases', FieldNameAliases),
-    ('query_indexes', QueryIndexes),
-])
+    if has_similarity:
+        following.append(('similarity_function', Int))
+        defaults['similarity_function'] = 0
 
-QueryEntitiesNoSimilarity = StructArray([
-    ('key_type_name', String),
-    ('value_type_name', String),
-    ('table_name', String),
-    ('key_field_name', String),
-    ('value_field_name', String),
-    ('query_fields', QueryFields),
-    ('field_name_aliases', FieldNameAliases),
-    ('query_indexes', QueryIndexesNoSimilarity),
-])
+    if has_hnsw_params:
+        following.append(('hnsw_m', Int))
+        following.append(('hnsw_ef_construction', Int))
+        defaults['hnsw_m'] = HNSW_ENGINE_DEFAULT
+        defaults['hnsw_ef_construction'] = HNSW_ENGINE_DEFAULT
+
+    return StructArray(following, defaults=defaults)
+
+
+@lru_cache(maxsize=None)
+def query_entities_struct(has_similarity: bool, has_hnsw_params: bool) -> StructArray:
+    """
+    Query entities carrying the index layout for the given pair of negotiated features.
+
+    Memoised: the layout depends on nothing but the two flags, and both the cache config
+    struct and the query-entities cache property need the same instance.
+    """
+    return StructArray([
+        ('key_type_name', String),
+        ('value_type_name', String),
+        ('table_name', String),
+        ('key_field_name', String),
+        ('value_field_name', String),
+        ('query_fields', QueryFields),
+        ('field_name_aliases', FieldNameAliases),
+        ('query_indexes', _query_indexes(has_similarity, has_hnsw_params)),
+    ])
+
+
+def query_entities_for(protocol_context) -> StructArray:
+    """
+    Pick the query entities layout matching what this connection negotiated.
+    """
+    return query_entities_struct(
+        bool(protocol_context and protocol_context.is_query_index_vector_similarity_supported()),
+        bool(protocol_context and protocol_context.is_query_index_vector_hnsw_params_supported()),
+    )
+
+
+# Named layouts for the combinations that predate the HNSW build parameters. Kept because
+# they are imported elsewhere in the package and read more clearly than a flag pair.
+QueryIndexes = _query_indexes(True, False)
+QueryIndexesNoSimilarity = _query_indexes(False, False)
+QueryEntities = query_entities_struct(True, False)
+QueryEntitiesNoSimilarity = query_entities_struct(False, False)
 
 
 CacheKeyConfiguration = StructArray([
@@ -174,10 +216,7 @@ def get_cache_config_struct(protocol_context):
         ('write_synchronization_mode', WriteSynchronizationMode),
         ('cache_key_configuration', CacheKeyConfiguration),
     ]
-    if protocol_context.is_query_index_vector_similarity_supported():
-        fields.append(('query_entities', QueryEntities))
-    else:
-        fields.append(('query_entities', QueryEntitiesNoSimilarity))
+    fields.append(('query_entities', query_entities_for(protocol_context)))
     if protocol_context.is_expiry_policy_supported():
         fields.append(('expiry_policy', ExpiryPolicy))
     return Struct(fields=fields)

--- a/pygridgain/datatypes/cache_properties.py
+++ b/pygridgain/datatypes/cache_properties.py
@@ -17,11 +17,14 @@ import ctypes
 import math
 from typing import Union
 
+from functools import lru_cache
+
 from . import ExpiryPolicy
 from .prop_codes import *
 from .cache_config import (
     CacheMode, CacheAtomicityMode, PartitionLossPolicy, RebalanceMode,
     WriteSynchronizationMode, QueryEntities, QueryEntitiesNoSimilarity, CacheKeyConfiguration,
+    query_entities_struct,
 )
 from .primitive import *
 from .standard import *
@@ -42,9 +45,12 @@ __all__ = [
 
 
 def prop_map(code: int, protocol_context=None):
-    if code == PROP_QUERY_ENTITIES and protocol_context and not protocol_context.is_query_index_vector_similarity_supported():
-        return PropQueryEntitiesNoSimilarity
-    
+    if code == PROP_QUERY_ENTITIES and protocol_context:
+        return _prop_query_entities(
+            bool(protocol_context.is_query_index_vector_similarity_supported()),
+            bool(protocol_context.is_query_index_vector_hnsw_params_supported()),
+        )
+
     return {
         PROP_NAME: PropName,
         PROP_CACHE_MODE: PropCacheMode,
@@ -205,9 +211,32 @@ class PropQueryEntities(PropBase):
     prop_code = PROP_QUERY_ENTITIES
     prop_data_class = QueryEntities
 
+
 class PropQueryEntitiesNoSimilarity(PropBase):
     prop_code = PROP_QUERY_ENTITIES
     prop_data_class = QueryEntitiesNoSimilarity
+
+
+@lru_cache(maxsize=None)
+def _prop_query_entities(has_similarity: bool, has_hnsw_params: bool):
+    """
+    The query entities property whose payload matches what the connection negotiated.
+
+    The two pre-HNSW combinations keep their named classes so that behaviour against an
+    older cluster stays byte-for-byte what it was; the rest are generated on demand.
+    """
+    if not has_hnsw_params:
+        return PropQueryEntities if has_similarity else PropQueryEntitiesNoSimilarity
+
+    return type(
+        'PropQueryEntitiesHnswParams' if has_similarity else 'PropQueryEntitiesHnswParamsNoSimilarity',
+        (PropBase,),
+        {
+            'prop_code': PROP_QUERY_ENTITIES,
+            'prop_data_class': query_entities_struct(has_similarity, has_hnsw_params),
+        },
+    )
+
 
 class PropQueryParallelism(PropBase):
     prop_code = PROP_QUERY_PARALLELISM

--- a/pygridgain/datatypes/cache_properties.py
+++ b/pygridgain/datatypes/cache_properties.py
@@ -222,8 +222,10 @@ def _prop_query_entities(has_similarity: bool, has_hnsw_params: bool):
     """
     The query entities property whose payload matches what the connection negotiated.
 
-    The two pre-HNSW combinations keep their named classes so that behaviour against an
-    older cluster stays byte-for-byte what it was; the rest are generated on demand.
+    The two combinations that predate the HNSW build parameters keep their named classes;
+    the rest are generated on demand. Note this is not a byte-for-byte promise: the layouts
+    they carry now gate the trailing fields on the index being a VECTOR index, which is what
+    the server has always required.
     """
     if not has_hnsw_params:
         return PropQueryEntities if has_similarity else PropQueryEntitiesNoSimilarity

--- a/pygridgain/datatypes/internal.py
+++ b/pygridgain/datatypes/internal.py
@@ -156,7 +156,7 @@ class StructArray:
     defaults = attr.ib(type=dict, default={})
 
     def parse(self, stream):
-        fields, length = self.__parse_header(stream)
+        fields, length = self._parse_header(stream)
 
         for i in range(length):
             c_type = Struct(self.following).parse(stream)
@@ -165,7 +165,7 @@ class StructArray:
         return self.build_c_type(fields)
 
     async def parse_async(self, stream):
-        fields, length = self.__parse_header(stream)
+        fields, length = self._parse_header(stream)
 
         for i in range(length):
             c_type = await Struct(self.following).parse_async(stream)
@@ -173,7 +173,7 @@ class StructArray:
 
         return self.build_c_type(fields)
 
-    def __parse_header(self, stream):
+    def _parse_header(self, stream):
         counter_sz = ctypes.sizeof(self.counter_type)
         length = int.from_bytes(
             stream.slice(offset=counter_sz),
@@ -209,7 +209,7 @@ class StructArray:
         return await asyncio.gather(*result_coro)
 
     def from_python(self, stream, value):
-        self.__write_header(stream, len(value))
+        self._write_header(stream, len(value))
 
         for v in value:
             for default_key, default_value in self.defaults.items():
@@ -218,7 +218,7 @@ class StructArray:
                 el_class.from_python(stream, v[name])
 
     async def from_python_async(self, stream, value):
-        self.__write_header(stream, len(value))
+        self._write_header(stream, len(value))
 
         for v in value:
             for default_key, default_value in self.defaults.items():
@@ -226,7 +226,7 @@ class StructArray:
             for name, el_class in self.following:
                 await el_class.from_python_async(stream, v[name])
 
-    def __write_header(self, stream, length):
+    def _write_header(self, stream, length):
         stream.write(
             length.to_bytes(ctypes.sizeof(self.counter_type),
                             byteorder=PROTOCOL_BYTE_ORDER)

--- a/tests/test_query_index_hnsw_params.py
+++ b/tests/test_query_index_hnsw_params.py
@@ -1,0 +1,150 @@
+#
+# Copyright 2026 GridGain Systems, Inc. and Contributors.
+#
+# Licensed under the GridGain Community Edition License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Wire layout of the per-index HNSW build parameters (GG-49543).
+
+The server appends ``hnsw_m`` and ``hnsw_ef_construction`` to a query index only when
+feature bit 38 was negotiated. Get the layout wrong in either direction and the cache
+configuration stream desynchronises, so these tests pin the field order and the gating
+rather than any behaviour a cluster would show.
+"""
+
+import pytest
+
+from pygridgain.connection.bitmask_feature import BitmaskFeature
+from pygridgain.connection.protocol_context import ProtocolContext
+from pygridgain.datatypes.cache_config import (
+    HNSW_ENGINE_DEFAULT, MAX_HNSW_EF_CONSTRUCTION, MAX_HNSW_M,
+    get_cache_config_struct, query_entities_struct,
+)
+from pygridgain.datatypes.cache_properties import prop_map
+from pygridgain.datatypes.prop_codes import PROP_QUERY_ENTITIES
+
+# Feature flags only exist from 1.7.0; ProtocolContext drops them below that.
+VERSION = (1, 7, 1)
+
+SIMILARITY = BitmaskFeature.QUERY_INDEX_VECTOR_SIMILARITY
+HNSW = BitmaskFeature.QUERY_INDEX_VECTOR_HNSW_PARAMS
+
+BASE_INDEX_FIELDS = ['index_name', 'index_type', 'inline_size', 'fields']
+
+
+def context(*features):
+    """A protocol context advertising exactly the given features."""
+    mask = BitmaskFeature(0)
+    for feature in features:
+        mask |= feature
+    return ProtocolContext(VERSION, mask)
+
+
+def index_field_names(has_similarity, has_hnsw_params):
+    entities = query_entities_struct(has_similarity, has_hnsw_params)
+    query_indexes = dict(entities.following)['query_indexes']
+    return [name for name, _ in query_indexes.following]
+
+
+def test_feature_bit_is_38():
+    # The server side is ClientBitmaskFeature.QUERY_INDEX_VECTOR_HNSW_PARAMS(38).
+    assert HNSW == 1 << 38
+
+
+def test_feature_is_advertised_as_supported():
+    assert HNSW in BitmaskFeature.all_supported()
+
+
+def test_hnsw_bounds_match_the_server():
+    # Mirrors QueryIndex.HNSW_ENGINE_DEFAULT / MAX_HNSW_M / MAX_HNSW_EF_CONSTRUCTION.
+    assert (HNSW_ENGINE_DEFAULT, MAX_HNSW_M, MAX_HNSW_EF_CONSTRUCTION) == (0, 512, 3200)
+
+
+@pytest.mark.parametrize(
+    'features, supported',
+    [
+        ((), False),
+        ((SIMILARITY,), False),
+        ((HNSW,), True),
+        ((SIMILARITY, HNSW), True),
+    ],
+)
+def test_protocol_context_reports_the_feature(features, supported):
+    assert bool(context(*features).is_query_index_vector_hnsw_params_supported()) is supported
+
+
+def test_feature_is_not_reported_below_1_7_0():
+    # Below 1.7.0 the feature mask is dropped wholesale, so nothing may be claimed.
+    stale = ProtocolContext((1, 6, 0), BitmaskFeature(0) | HNSW)
+    assert not stale.is_query_index_vector_hnsw_params_supported()
+
+
+@pytest.mark.parametrize(
+    'has_similarity, has_hnsw_params, expected',
+    [
+        (False, False, BASE_INDEX_FIELDS),
+        (True, False, BASE_INDEX_FIELDS + ['similarity_function']),
+        (False, True, BASE_INDEX_FIELDS + ['hnsw_m', 'hnsw_ef_construction']),
+        (True, True, BASE_INDEX_FIELDS + ['similarity_function', 'hnsw_m', 'hnsw_ef_construction']),
+    ],
+)
+def test_index_layout_tracks_the_negotiated_features(has_similarity, has_hnsw_params, expected):
+    # Order matters as much as presence: the server writes similarity first, then the
+    # HNSW pair, both at the end of the index.
+    assert index_field_names(has_similarity, has_hnsw_params) == expected
+
+
+def test_hnsw_params_default_to_engine_default():
+    entities = query_entities_struct(True, True)
+    defaults = dict(entities.following)['query_indexes'].defaults
+    assert defaults['hnsw_m'] == HNSW_ENGINE_DEFAULT
+    assert defaults['hnsw_ef_construction'] == HNSW_ENGINE_DEFAULT
+
+
+def test_layout_is_shared_between_config_and_property():
+    # The cache config struct and the query entities property must agree byte for byte;
+    # they agree because both resolve through the same memoised layout.
+    ctx = context(SIMILARITY, HNSW)
+
+    from_config = dict(get_cache_config_struct(ctx).fields)['query_entities']
+    from_property = prop_map(PROP_QUERY_ENTITIES, ctx).prop_data_class
+
+    assert from_config is from_property
+    assert from_config is query_entities_struct(True, True)
+
+
+@pytest.mark.parametrize(
+    'features, has_similarity, has_hnsw_params',
+    [
+        ((), False, False),
+        ((SIMILARITY,), True, False),
+        ((SIMILARITY, HNSW), True, True),
+    ],
+)
+def test_cache_config_struct_selects_the_negotiated_layout(features, has_similarity, has_hnsw_params):
+    struct = get_cache_config_struct(context(*features))
+    assert dict(struct.fields)['query_entities'] is query_entities_struct(has_similarity, has_hnsw_params)
+
+
+def test_property_layout_is_unchanged_without_the_new_feature():
+    # Guards the compatibility promise: talking to a cluster that predates bit 38 must
+    # put exactly the same bytes on the wire as before this change.
+    ctx = context(SIMILARITY)
+    assert index_field_names(True, False) == BASE_INDEX_FIELDS + ['similarity_function']
+    assert prop_map(PROP_QUERY_ENTITIES, ctx).prop_data_class is query_entities_struct(True, False)
+
+
+def test_prop_map_without_context_keeps_the_legacy_default():
+    from pygridgain.datatypes.cache_properties import PropQueryEntities
+
+    assert prop_map(PROP_QUERY_ENTITIES) is PropQueryEntities

--- a/tests/test_query_index_hnsw_params.py
+++ b/tests/test_query_index_hnsw_params.py
@@ -14,12 +14,16 @@
 # limitations under the License.
 #
 """
-Wire layout of the per-index HNSW build parameters (GG-49543).
+Wire layout of the query index trailing fields (GG-49543).
 
-The server appends ``hnsw_m`` and ``hnsw_ef_construction`` to a query index only when
-feature bit 38 was negotiated. Get the layout wrong in either direction and the cache
-configuration stream desynchronises, so these tests pin the field order and the gating
-rather than any behaviour a cluster would show.
+The server appends ``similarity_function`` and the HNSW build parameters to an index only
+when the matching feature bit was negotiated AND that index is a VECTOR index:
+
+    if (writeSimilarityFunction && idx.getIndexType() == VECTOR)  writeInt(similarityId);
+    if (writeHnswParams        && idx.getIndexType() == VECTOR) { writeInt(m); writeInt(ef); }
+
+Both halves of that condition matter. These tests pin the bytes rather than the declared
+field list, because a layout that is merely self-consistent still desynchronises the stream.
 """
 
 import pytest
@@ -27,11 +31,12 @@ import pytest
 from pygridgain.connection.bitmask_feature import BitmaskFeature
 from pygridgain.connection.protocol_context import ProtocolContext
 from pygridgain.datatypes.cache_config import (
-    HNSW_ENGINE_DEFAULT, MAX_HNSW_EF_CONSTRUCTION, MAX_HNSW_M,
+    HNSW_ENGINE_DEFAULT, MAX_HNSW_EF_CONSTRUCTION, MAX_HNSW_M, IndexType,
     get_cache_config_struct, query_entities_struct,
 )
 from pygridgain.datatypes.cache_properties import prop_map
 from pygridgain.datatypes.prop_codes import PROP_QUERY_ENTITIES
+from pygridgain.stream.binary_stream import BinaryStream
 
 # Feature flags only exist from 1.7.0; ProtocolContext drops them below that.
 VERSION = (1, 7, 1)
@@ -40,6 +45,14 @@ SIMILARITY = BitmaskFeature.QUERY_INDEX_VECTOR_SIMILARITY
 HNSW = BitmaskFeature.QUERY_INDEX_VECTOR_HNSW_PARAMS
 
 BASE_INDEX_FIELDS = ['index_name', 'index_type', 'inline_size', 'fields']
+
+ALL_COMBINATIONS = [(False, False), (True, False), (False, True), (True, True)]
+
+SORTED_INDEX = {'index_name': 'by_name', 'index_type': IndexType.SORTED, 'inline_size': -1,
+                'fields': [{'name': 'name'}]}
+VECTOR_INDEX = {'index_name': 'by_embedding', 'index_type': IndexType.VECTOR, 'inline_size': -1,
+                'fields': [{'name': 'embedding'}], 'similarity_function': 1,
+                'hnsw_m': 16, 'hnsw_ef_construction': 100}
 
 
 def context(*features):
@@ -50,11 +63,36 @@ def context(*features):
     return ProtocolContext(VERSION, mask)
 
 
-def index_field_names(has_similarity, has_hnsw_params):
-    entities = query_entities_struct(has_similarity, has_hnsw_params)
-    query_indexes = dict(entities.following)['query_indexes']
-    return [name for name, _ in query_indexes.following]
+def entity(indexes):
+    return {
+        'key_type_name': 'K', 'value_type_name': 'V', 'table_name': 'T',
+        'key_field_name': None, 'value_field_name': None,
+        'query_fields': [], 'field_name_aliases': [],
+        # copied: serialization fills defaults into the dicts it is handed
+        'query_indexes': [dict(index) for index in indexes],
+    }
 
+
+def serialize(has_similarity, has_hnsw_params, indexes):
+    stream = BinaryStream(None)
+    query_entities_struct(has_similarity, has_hnsw_params).from_python(stream, [entity(indexes)])
+    return stream.getvalue()
+
+
+def round_trip(has_similarity, has_hnsw_params, indexes):
+    struct = query_entities_struct(has_similarity, has_hnsw_params)
+    stream = BinaryStream(None, serialize(has_similarity, has_hnsw_params, indexes))
+    c_type = struct.parse(stream)
+    stream.seek(0)
+    return struct.to_python(stream.read_ctype(c_type))[0]['query_indexes']
+
+
+def declared_fields(has_similarity, has_hnsw_params):
+    entities = query_entities_struct(has_similarity, has_hnsw_params)
+    return [name for name, _ in dict(entities.following)['query_indexes'].following]
+
+
+# --- the feature bit itself ------------------------------------------------------------
 
 def test_feature_bit_is_38():
     # The server side is ClientBitmaskFeature.QUERY_INDEX_VECTOR_HNSW_PARAMS(38).
@@ -72,12 +110,7 @@ def test_hnsw_bounds_match_the_server():
 
 @pytest.mark.parametrize(
     'features, supported',
-    [
-        ((), False),
-        ((SIMILARITY,), False),
-        ((HNSW,), True),
-        ((SIMILARITY, HNSW), True),
-    ],
+    [((), False), ((SIMILARITY,), False), ((HNSW,), True), ((SIMILARITY, HNSW), True)],
 )
 def test_protocol_context_reports_the_feature(features, supported):
     assert bool(context(*features).is_query_index_vector_hnsw_params_supported()) is supported
@@ -89,6 +122,79 @@ def test_feature_is_not_reported_below_1_7_0():
     assert not stale.is_query_index_vector_hnsw_params_supported()
 
 
+# --- what actually goes on the wire ----------------------------------------------------
+
+@pytest.mark.parametrize('has_similarity, has_hnsw_params', ALL_COMBINATIONS)
+def test_non_vector_index_is_byte_identical_whatever_was_negotiated(has_similarity, has_hnsw_params):
+    # The server writes and reads no trailing fields for a SORTED index under any feature
+    # bit, so neither may the client: stray bytes here displace every index after them.
+    baseline = serialize(False, False, [SORTED_INDEX])
+    assert serialize(has_similarity, has_hnsw_params, [SORTED_INDEX]) == baseline
+
+
+@pytest.mark.parametrize(
+    'has_similarity, has_hnsw_params, extra_bytes',
+    [
+        (False, False, 0),
+        (True, False, 4),           # similarity_function
+        (False, True, 8),           # hnsw_m + hnsw_ef_construction
+        (True, True, 12),           # all three
+    ],
+)
+def test_vector_index_gains_exactly_the_negotiated_fields(has_similarity, has_hnsw_params, extra_bytes):
+    baseline = len(serialize(False, False, [VECTOR_INDEX]))
+    assert len(serialize(has_similarity, has_hnsw_params, [VECTOR_INDEX])) == baseline + extra_bytes
+
+
+@pytest.mark.parametrize('indexes', [
+    [SORTED_INDEX, VECTOR_INDEX],
+    [VECTOR_INDEX, SORTED_INDEX],
+])
+def test_mixed_index_array_round_trips(indexes):
+    # The regression that a flat layout causes: the trailing fields of one index get read
+    # as the head of the next, and the array length of a later field becomes garbage.
+    parsed = round_trip(True, True, indexes)
+
+    assert [index['index_name'] for index in parsed] == [index['index_name'] for index in indexes]
+
+    for original, actual in zip(indexes, parsed):
+        assert actual['index_type'] == original['index_type']
+        if original['index_type'] == IndexType.VECTOR:
+            assert actual['similarity_function'] == original['similarity_function']
+            assert actual['hnsw_m'] == original['hnsw_m']
+            assert actual['hnsw_ef_construction'] == original['hnsw_ef_construction']
+        else:
+            assert 'similarity_function' not in actual
+            assert 'hnsw_m' not in actual
+            assert 'hnsw_ef_construction' not in actual
+
+
+def test_vector_index_round_trips_the_engine_default():
+    # Zero is "let the engine choose", and is what a pre-GG-49543 index deserializes to.
+    index = dict(VECTOR_INDEX, hnsw_m=HNSW_ENGINE_DEFAULT, hnsw_ef_construction=HNSW_ENGINE_DEFAULT)
+    parsed = round_trip(True, True, [index])[0]
+    assert parsed['hnsw_m'] == HNSW_ENGINE_DEFAULT
+    assert parsed['hnsw_ef_construction'] == HNSW_ENGINE_DEFAULT
+
+
+def test_hnsw_params_default_to_engine_default_when_omitted():
+    index = {k: v for k, v in VECTOR_INDEX.items() if not k.startswith('hnsw_')}
+    parsed = round_trip(True, True, [index])[0]
+    assert parsed['hnsw_m'] == HNSW_ENGINE_DEFAULT
+    assert parsed['hnsw_ef_construction'] == HNSW_ENGINE_DEFAULT
+
+
+def test_defaults_are_not_injected_into_a_non_vector_index():
+    # A SORTED index has no HNSW parameters at all; filling them in would be misleading
+    # to any caller that inspects the dict it passed in.
+    index = dict(SORTED_INDEX)
+    serialize(True, True, [index])
+    assert 'hnsw_m' not in index
+    assert 'similarity_function' not in index
+
+
+# --- layout selection ------------------------------------------------------------------
+
 @pytest.mark.parametrize(
     'has_similarity, has_hnsw_params, expected',
     [
@@ -98,17 +204,10 @@ def test_feature_is_not_reported_below_1_7_0():
         (True, True, BASE_INDEX_FIELDS + ['similarity_function', 'hnsw_m', 'hnsw_ef_construction']),
     ],
 )
-def test_index_layout_tracks_the_negotiated_features(has_similarity, has_hnsw_params, expected):
-    # Order matters as much as presence: the server writes similarity first, then the
-    # HNSW pair, both at the end of the index.
-    assert index_field_names(has_similarity, has_hnsw_params) == expected
-
-
-def test_hnsw_params_default_to_engine_default():
-    entities = query_entities_struct(True, True)
-    defaults = dict(entities.following)['query_indexes'].defaults
-    assert defaults['hnsw_m'] == HNSW_ENGINE_DEFAULT
-    assert defaults['hnsw_ef_construction'] == HNSW_ENGINE_DEFAULT
+def test_declared_layout_tracks_the_negotiated_features(has_similarity, has_hnsw_params, expected):
+    # Which trailing fields can exist at all, in wire order. Whether a given index carries
+    # them is decided per index — see the byte-level tests above.
+    assert declared_fields(has_similarity, has_hnsw_params) == expected
 
 
 def test_layout_is_shared_between_config_and_property():
@@ -125,23 +224,19 @@ def test_layout_is_shared_between_config_and_property():
 
 @pytest.mark.parametrize(
     'features, has_similarity, has_hnsw_params',
-    [
-        ((), False, False),
-        ((SIMILARITY,), True, False),
-        ((SIMILARITY, HNSW), True, True),
-    ],
+    [((), False, False), ((SIMILARITY,), True, False), ((SIMILARITY, HNSW), True, True)],
 )
 def test_cache_config_struct_selects_the_negotiated_layout(features, has_similarity, has_hnsw_params):
     struct = get_cache_config_struct(context(*features))
     assert dict(struct.fields)['query_entities'] is query_entities_struct(has_similarity, has_hnsw_params)
 
 
-def test_property_layout_is_unchanged_without_the_new_feature():
-    # Guards the compatibility promise: talking to a cluster that predates bit 38 must
-    # put exactly the same bytes on the wire as before this change.
+def test_bytes_are_unchanged_against_a_cluster_without_bit_38():
+    # Compatibility promise: a cluster that predates bit 38 must see exactly what it saw
+    # before this change, for vector and non-vector indexes alike.
     ctx = context(SIMILARITY)
-    assert index_field_names(True, False) == BASE_INDEX_FIELDS + ['similarity_function']
     assert prop_map(PROP_QUERY_ENTITIES, ctx).prop_data_class is query_entities_struct(True, False)
+    assert declared_fields(True, False) == BASE_INDEX_FIELDS + ['similarity_function']
 
 
 def test_prop_map_without_context_keeps_the_legacy_default():

--- a/tests/test_query_index_hnsw_params.py
+++ b/tests/test_query_index_hnsw_params.py
@@ -292,11 +292,24 @@ def test_engine_default_hnsw_params_are_accepted_without_the_feature():
     assert serialize(True, False, [index]) == serialize(True, False, [VECTOR_INDEX_NO_HNSW])
 
 
-def test_non_vector_index_may_not_smuggle_hnsw_params():
-    # The server rejects HNSW parameters on a non-vector index outright; the wire format
-    # gives them nowhere to go, so they are simply not sent.
-    index = dict(SORTED_INDEX, hnsw_m=64, hnsw_ef_construction=400)
-    assert serialize(True, True, [index]) == serialize(False, False, [SORTED_INDEX])
+@pytest.mark.parametrize('index_type', NON_VECTOR_TYPES)
+@pytest.mark.parametrize('has_hnsw_params', [True, False])
+def test_hnsw_params_on_a_non_vector_index_are_refused(index_type, has_hnsw_params):
+    # The server refuses this outright (QueryUtils.validateHnswParams). The wire format gives
+    # the values nowhere to go, so without an explicit refusal they vanish silently and the
+    # user only finds out by measuring recall. Caught against a live node, GG-49543.
+    index = dict(SORTED_INDEX, index_type=index_type, hnsw_m=64, hnsw_ef_construction=400)
+
+    with pytest.raises(ValueError, match='VECTOR indexes only'):
+        serialize(True, has_hnsw_params, [index])
+
+
+@pytest.mark.parametrize('index_type', NON_VECTOR_TYPES)
+def test_non_vector_index_without_hnsw_params_is_unaffected(index_type):
+    # The refusal must trigger on the values, not on the index type: an ordinary index that
+    # sets nothing still serialises exactly as before.
+    index = dict(SORTED_INDEX, index_type=index_type)
+    assert serialize(True, True, [index]) == serialize(False, False, [index])
 
 
 @pytest.mark.asyncio

--- a/tests/test_query_index_hnsw_params.py
+++ b/tests/test_query_index_hnsw_params.py
@@ -36,6 +36,8 @@ from pygridgain.datatypes.cache_config import (
 )
 from pygridgain.datatypes.cache_properties import prop_map
 from pygridgain.datatypes.prop_codes import PROP_QUERY_ENTITIES
+from pygridgain.exceptions import NotSupportedByClusterError
+from pygridgain.stream import AioBinaryStream
 from pygridgain.stream.binary_stream import BinaryStream
 
 # Feature flags only exist from 1.7.0; ProtocolContext drops them below that.
@@ -53,6 +55,12 @@ SORTED_INDEX = {'index_name': 'by_name', 'index_type': IndexType.SORTED, 'inline
 VECTOR_INDEX = {'index_name': 'by_embedding', 'index_type': IndexType.VECTOR, 'inline_size': -1,
                 'fields': [{'name': 'embedding'}], 'similarity_function': 1,
                 'hnsw_m': 16, 'hnsw_ef_construction': 100}
+
+VECTOR_INDEX_NO_HNSW = {k: v for k, v in VECTOR_INDEX.items() if not k.startswith('hnsw_')}
+
+# Every index type that is NOT a vector index carries no trailing fields at all. Covering
+# more than SORTED is what stops the gate degrading into "anything but SORTED".
+NON_VECTOR_TYPES = [IndexType.SORTED, IndexType.FULLTEXT, IndexType.GEOSPATIAL]
 
 
 def context(*features):
@@ -125,11 +133,14 @@ def test_feature_is_not_reported_below_1_7_0():
 # --- what actually goes on the wire ----------------------------------------------------
 
 @pytest.mark.parametrize('has_similarity, has_hnsw_params', ALL_COMBINATIONS)
-def test_non_vector_index_is_byte_identical_whatever_was_negotiated(has_similarity, has_hnsw_params):
-    # The server writes and reads no trailing fields for a SORTED index under any feature
-    # bit, so neither may the client: stray bytes here displace every index after them.
-    baseline = serialize(False, False, [SORTED_INDEX])
-    assert serialize(has_similarity, has_hnsw_params, [SORTED_INDEX]) == baseline
+@pytest.mark.parametrize('index_type', NON_VECTOR_TYPES)
+def test_non_vector_index_is_byte_identical_whatever_was_negotiated(
+        index_type, has_similarity, has_hnsw_params):
+    # The server writes and reads no trailing fields for a non-vector index under any
+    # feature bit, so neither may the client: stray bytes displace every index after them.
+    index = dict(SORTED_INDEX, index_type=index_type)
+    baseline = serialize(False, False, [index])
+    assert serialize(has_similarity, has_hnsw_params, [index]) == baseline
 
 
 @pytest.mark.parametrize(
@@ -142,8 +153,19 @@ def test_non_vector_index_is_byte_identical_whatever_was_negotiated(has_similari
     ],
 )
 def test_vector_index_gains_exactly_the_negotiated_fields(has_similarity, has_hnsw_params, extra_bytes):
-    baseline = len(serialize(False, False, [VECTOR_INDEX]))
-    assert len(serialize(has_similarity, has_hnsw_params, [VECTOR_INDEX])) == baseline + extra_bytes
+    # Only ask for the parameters the layout can carry; asking for more is refused, and is
+    # covered by test_hnsw_params_are_refused_when_the_cluster_cannot_carry_them.
+    index = VECTOR_INDEX if has_hnsw_params else VECTOR_INDEX_NO_HNSW
+    baseline = len(serialize(False, False, [VECTOR_INDEX_NO_HNSW]))
+    assert len(serialize(has_similarity, has_hnsw_params, [index])) == baseline + extra_bytes
+
+
+@pytest.mark.parametrize('index_type', NON_VECTOR_TYPES)
+@pytest.mark.parametrize('order', ['non_vector_first', 'vector_first'])
+def test_mixed_index_array_round_trips_for_every_non_vector_type(index_type, order):
+    other = dict(SORTED_INDEX, index_type=index_type)
+    indexes = [other, VECTOR_INDEX] if order == 'non_vector_first' else [VECTOR_INDEX, other]
+    _assert_round_trip(indexes)
 
 
 @pytest.mark.parametrize('indexes', [
@@ -151,6 +173,10 @@ def test_vector_index_gains_exactly_the_negotiated_fields(has_similarity, has_hn
     [VECTOR_INDEX, SORTED_INDEX],
 ])
 def test_mixed_index_array_round_trips(indexes):
+    _assert_round_trip(indexes)
+
+
+def _assert_round_trip(indexes):
     # The regression that a flat layout causes: the trailing fields of one index get read
     # as the head of the next, and the array length of a later field becomes garbage.
     parsed = round_trip(True, True, indexes)
@@ -231,12 +257,70 @@ def test_cache_config_struct_selects_the_negotiated_layout(features, has_similar
     assert dict(struct.fields)['query_entities'] is query_entities_struct(has_similarity, has_hnsw_params)
 
 
-def test_bytes_are_unchanged_against_a_cluster_without_bit_38():
-    # Compatibility promise: a cluster that predates bit 38 must see exactly what it saw
-    # before this change, for vector and non-vector indexes alike.
+def test_vector_index_bytes_are_unchanged_against_a_cluster_without_bit_38():
+    # A cluster that predates bit 38 must see exactly the bytes it saw before: base fields
+    # plus the similarity int, and nothing else.
     ctx = context(SIMILARITY)
     assert prop_map(PROP_QUERY_ENTITIES, ctx).prop_data_class is query_entities_struct(True, False)
-    assert declared_fields(True, False) == BASE_INDEX_FIELDS + ['similarity_function']
+
+    with_bit_33 = serialize(True, False, [VECTOR_INDEX_NO_HNSW])
+    assert len(with_bit_33) == len(serialize(False, False, [VECTOR_INDEX_NO_HNSW])) + 4
+    # ...and the similarity value is the last four bytes of the index record.
+    assert with_bit_33.endswith((1).to_bytes(4, byteorder='little'))
+
+
+def test_non_vector_index_under_bit_33_carries_no_similarity_int():
+    # The pre-existing shape this change corrects: the server has gated similarity on
+    # indexType == VECTOR since it was introduced, so a SORTED index never carried it.
+    assert serialize(True, False, [SORTED_INDEX]) == serialize(False, False, [SORTED_INDEX])
+
+
+def test_hnsw_params_are_refused_when_the_cluster_cannot_carry_them():
+    # Dropping them silently would build a graph the caller did not ask for. Mirrors the
+    # Java thin client, and this client's own handling of efSearch in GG-49286.
+    with pytest.raises(NotSupportedByClusterError):
+        serialize(True, False, [dict(VECTOR_INDEX, hnsw_m=64)])
+
+    with pytest.raises(NotSupportedByClusterError):
+        serialize(True, False, [dict(VECTOR_INDEX, hnsw_ef_construction=400)])
+
+
+def test_engine_default_hnsw_params_are_accepted_without_the_feature():
+    # Asking for nothing is not asking for something unsupported.
+    index = dict(VECTOR_INDEX, hnsw_m=HNSW_ENGINE_DEFAULT,
+                 hnsw_ef_construction=HNSW_ENGINE_DEFAULT)
+    assert serialize(True, False, [index]) == serialize(True, False, [VECTOR_INDEX_NO_HNSW])
+
+
+def test_non_vector_index_may_not_smuggle_hnsw_params():
+    # The server rejects HNSW parameters on a non-vector index outright; the wire format
+    # gives them nowhere to go, so they are simply not sent.
+    index = dict(SORTED_INDEX, hnsw_m=64, hnsw_ef_construction=400)
+    assert serialize(True, True, [index]) == serialize(False, False, [SORTED_INDEX])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('indexes', [
+    [SORTED_INDEX, VECTOR_INDEX],
+    [VECTOR_INDEX, SORTED_INDEX],
+])
+async def test_async_path_matches_the_sync_path(indexes):
+    # parse_async / from_python_async / to_python_async are hand-duplicated from the sync
+    # versions and are what cache_get_configuration_async actually runs.
+    struct = query_entities_struct(True, True)
+
+    stream = AioBinaryStream(None)
+    await struct.from_python_async(stream, [entity(indexes)])
+    written = stream.getvalue()
+
+    assert written == serialize(True, True, indexes)
+
+    stream = AioBinaryStream(None, written)
+    c_type = await struct.parse_async(stream)
+    stream.seek(0)
+    parsed = (await struct.to_python_async(stream.read_ctype(c_type)))[0]['query_indexes']
+
+    assert parsed == round_trip(True, True, indexes)
 
 
 def test_prop_map_without_context_keeps_the_legacy_default():


### PR DESCRIPTION
Ticket: [GG-49543](https://ggsystems.atlassian.net/browse/GG-49543)

Teaches the client two new optional integers on a vector query index — `hnsw_m` and `hnsw_ef_construction` — negotiated through a new protocol feature bit. Same shape as GG-49286 (#80) and GG-43272 (#77): the server gained a feature bit, and the client learns to advertise it and match the wire layout.

Server side is CE https://github.com/gridgain/gridgain/pull/3955 and EE https://github.com/ggprivate/ggprivate/pull/2362.

**Please read the second section — this PR also corrects an existing wire bug, so it is not purely additive.**

## 1. The new feature

| File | Change |
|---|---|
| `connection/bitmask_feature.py` | `QUERY_INDEX_VECTOR_HNSW_PARAMS = 1 << 38` |
| `connection/protocol_context.py` | `is_query_index_vector_hnsw_params_supported()` |
| `datatypes/cache_config.py` | the layout work below |
| `datatypes/cache_properties.py` | picks the property whose payload matches what was negotiated |
| `docs/datatypes/cache_props.rst` | documents the three vector-index keys (`similarity_function` was undocumented too) |

Both values default to `0`, meaning "let the engine choose". An index read back from a server that doesn't send them has the keys **absent** from the dict rather than set to `0`.

Rather than adding a third and fourth hardcoded struct variant, the query-index layout is now **built from the two negotiated flags and memoised**, so the cache config struct and the query entities property always resolve to the same instance. That is what the `query_entities_struct(has_similarity, has_hnsw_params)` + `lru_cache` pair is doing.

## 2. The existing bug this had to fix

The server writes the trailing fields of a query index gated on **two** conditions — the feature bit **and** `indexType == VECTOR`:

```java
if (writeSimilarityFunction && idx.getIndexType() == VECTOR)  writeInt(similarityId);
if (writeHnswParams        && idx.getIndexType() == VECTOR) { writeInt(m); writeInt(ef); }
```

`StructArray` applies one field list to every element, so a non-VECTOR index has been sending a `similarity_function` the server never reads — **4 stray bytes on every SORTED/FULLTEXT/GEOSPATIAL index since GG-43272**, and this change would have taken that to 12. `git log -L` on the Java writer confirms the VECTOR gate was present in the very commit that introduced similarity, so no server version ever wrote it ungated.

It breaks in both directions. Parsing a real bit-33 server's payload for `[SORTED, VECTOR]` with the flat layout builds a **1,700,755,867-byte** structure and dies with `ValueError: Buffer size too small`; writing, the stray bytes get read as the next index's header.

The fix is a `QueryIndexArray(StructArray)` subclass that decides the element layout **per index** in all four directions (`from_python`, `parse`, `to_python`, and the async variants). A non-vector index is now byte-identical to the pre-GG-43272 baseline whatever was negotiated; a vector index carries exactly the negotiated fields.

Two small supporting changes: `datatypes/internal.py` drops the name mangling on `StructArray`'s two header helpers so the subclass can call them instead of keeping a copy that could drift; and `to_python` raises on an unrecognised field rather than silently dropping it.

## 3. Nothing is dropped silently

Three cases that used to pass quietly now raise:

- **HNSW params against a cluster without bit 38** → `NotSupportedByClusterError`. Previously the index was built with engine defaults and the caller never knew. Matches the Java thin client, and this client's own handling of `ef_search` in GG-49286.
- **HNSW params on a non-VECTOR index** → `ValueError`. The server refuses this outright (`QueryUtils.validateHnswParams`); the wire format gives the values nowhere to go, so without an explicit refusal they vanish. *Found by running all three PRs against a live node — the unit tests were happy.*
- **A parsed index carrying an unknown field** → `ParseError`.

## Compatibility

Against a cluster **without** bit 38, a vector index puts exactly the bytes on the wire that it did before. Against a cluster without bit 33 either, likewise. The one deliberate change is non-vector indexes, which stop sending the stray `similarity_function` — that moves them *towards* what the server has always expected.

## Tests

`tests/test_query_index_hnsw_params.py`, 59 tests, no cluster needed. They pin **bytes**, not descriptor names — a layout that is merely self-consistent still desynchronises against the server:

- non-vector byte-identity across all four bit combinations **and** SORTED/FULLTEXT/GEOSPATIAL (parametrised over three types deliberately: with only SORTED covered, mutating the gate to `!= SORTED` left every test passing);
- per-bit byte deltas on a vector index (+4 similarity, +8 HNSW, +12 both);
- mixed `[SORTED, VECTOR]` arrays round-tripping in both orders;
- the async path producing the same bytes and the same parse as the sync path;
- all three refusals above.

59 in the file, 103 non-cluster tests green, flake8 clean on all changed files.

**End-to-end against a live licensed node**, with CE and EE built from their branches: bit 38 negotiated, `hnsw_m=64` / `hnsw_ef_construction=400` set from Python and read back off the real cache configuration, unset reading back as `0`, the server rejecting `m=99999` with its own range message, and a non-vector index refused client-side. 7/7.

Not run: the cluster-backed suites under `tests/common` and friends, which need a node this repo's CI provides and I don't have here.

## Independent of the merge order

CE must merge before EE, but this client is independent of both — the feature bit is negotiated, so it degrades cleanly against any server.


[GG-49543]: https://ggsystems.atlassian.net/browse/GG-49543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ